### PR TITLE
feat: Add script and CI workflow to check init.el package order

### DIFF
--- a/.github/workflows/check-package-order.yml
+++ b/.github/workflows/check-package-order.yml
@@ -1,0 +1,29 @@
+name: Check Package Order
+
+on:
+  push:
+    branches:
+      - main # Assuming 'main' is the default branch
+  pull_request:
+    branches:
+      - main # Assuming 'main' is the default branch
+
+jobs:
+  check_package_order:
+    name: Check Package Order
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4 # Using a newer version like v4
+
+      - name: Set up Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: 'snapshot' # Using 'snapshot' as requested, could also be specific like '28.2'
+
+      - name: Make script executable
+        run: chmod +x scripts/check-package-order.el
+
+      - name: Run check-package-order script
+        run: scripts/check-package-order.el init.el

--- a/scripts/check-package-order.el
+++ b/scripts/check-package-order.el
@@ -1,0 +1,73 @@
+#!/usr/bin/env emacs --script
+
+;;; check-package-order.el --- Check if use-package declarations are sorted alphabetically
+
+(defun get-package-name-from-form (form)
+  "Extract package name from a (use-package <name> ...) form.
+Returns the package name as a string, or nil if not a valid use-package form."
+  (when (and (listp form)
+             (>= (length form) 2)
+             (eq (car form) 'use-package)
+             (symbolp (cadr form)))
+    (symbol-name (cadr form))))
+
+(defun check-package-order (filename)
+  "Check if (use-package ...) forms in FILENAME are alphabetically sorted.
+Prints a message and exits with 0 if sorted, or 1 if not sorted or an error occurs."
+  (condition-case err
+      (with-temp-buffer
+        (insert-file-contents filename)
+        (goto-char (point-min))
+        (let ((package-names '())
+              (current-form nil)
+              (parse-error nil))
+          (while (not (or (eobp) parse-error))
+            (condition-case read-err
+                (setq current-form (read (current-buffer)))
+              ('error
+               (message "Error parsing Elisp syntax: %s" (error-message-string read-err))
+               (setq parse-error t)))
+            (when current-form
+              (let ((pkg-name (get-package-name-from-form current-form)))
+                (when pkg-name
+                  (push pkg-name package-names)))))
+          (when parse-error
+            (exit 1))
+
+          (setq package-names (nreverse package-names))
+
+          (if (or (null package-names) (< (length package-names) 2))
+              (progn
+                (message "Package declarations are sorted.")
+                (exit 0))
+            (let ((prev-pkg (pop package-names))
+                  (current-pkg nil)
+                  (sorted t))
+              (while (and package-names sorted)
+                (setq current-pkg (pop package-names))
+                (if (string-lessp (downcase current-pkg) (downcase prev-pkg))
+                    (progn
+                      (message "Package '%s' should come before '%s'." current-pkg prev-pkg)
+                      (setq sorted nil))
+                  (setq prev-pkg current-pkg)))
+              (if sorted
+                  (progn
+                    (message "Package declarations are sorted.")
+                    (exit 0))
+                (exit 1))))))
+    ('file-error
+     (message "Error opening file: %s" (error-message-string err))
+     (exit 1))
+    ('error ; Catch any other unexpected errors
+     (message "An unexpected error occurred: %s" (error-message-string err))
+     (exit 1))))
+
+;; Entry point for command-line execution
+(if (null command-line-args-left)
+    (progn
+      (message "Usage: %s <filename>"
+               (if command-line-args-raw
+                   (car command-line-args-raw)
+                 "check-package-order.el"))
+      (exit 2)) ; Using 2 for usage errors
+  (check-package-order (car command-line-args-left)))

--- a/test-empty.el
+++ b/test-empty.el
@@ -1,0 +1,2 @@
+;; test-empty.el
+;; This file is intentionally empty.

--- a/test-no-use-package.el
+++ b/test-no-use-package.el
@@ -1,0 +1,7 @@
+;; test-no-use-package.el
+(message "This is a test file.")
+(defun my-function ()
+  (interactive)
+  (message "Hello!"))
+(setq my-variable 42)
+;; No use-package forms here

--- a/test-sorted.el
+++ b/test-sorted.el
@@ -1,0 +1,5 @@
+;; test-sorted.el
+(use-package alpha)
+(use-package beta)
+(use-package gamma)
+(use-package zeta)

--- a/test-syntax-error.el
+++ b/test-syntax-error.el
@@ -1,0 +1,11 @@
+;; test-syntax-error.el
+(use-package good-package)
+
+(use-package bad-package-form ; missing closing parenthesis
+  :init
+  (message "This package has an error in its definition")
+
+(use-package another-good-one)
+
+;; Example of an unterminated string
+(setq my-string "this string is not closed...

--- a/test-unsorted.el
+++ b/test-unsorted.el
@@ -1,0 +1,4 @@
+;; test-unsorted.el
+(use-package beta)
+(use-package alpha) ; Error: alpha should come before beta
+(use-package gamma)


### PR DESCRIPTION
Adds an Emacs Lisp script `scripts/check-package-order.el` that verifies if `use-package` declarations in a given Elisp file are alphabetically sorted.

A new GitHub Actions workflow `.github/workflows/check-package-order.yml` is also added. This workflow triggers on push and pull_request events to the main branch and runs the `check-package-order.el` script against the `init.el` file to ensure its packages are sorted.

This will help you maintain a consistent and organized `init.el` file.