### PR TITLE
Rename my-new-local-multi-vterm to vterm-local

### DIFF
--- a/init.el
+++ b/init.el
@@ -2148,7 +2148,7 @@ if ENV-SH indicates a remote path. Relies on the helper function
 (use-package multi-vterm :ensure t
   :config
   ;; Make a new vterm terminal from local computer
-  (defun my-new-local-multi-vterm ()
+  (defun vterm-local ()
     (interactive)
     (let ((default-directory (getenv "HOME")))
       (multi-vterm)))


### PR DESCRIPTION
- Simplify function name for better readability