### PR TITLE
Use markdown for gptel

### DIFF
--- a/init.el
+++ b/init.el
@@ -2444,7 +2444,6 @@ Improved Text:")
 
   (defvar my-enable-search-grounding t
     "Enable search grounding for Gemini requests.")
-  :custom (gptel-default-mode 'org-mode)
   )
 
 (use-package treesit


### PR DESCRIPTION
* LLM sometimes confuses the org-mode syntax and the markdown syntax.
* I decided to use markdown mode.