### PR TITLE
Adjust initial frame size and position

### DIFF
--- a/init.el
+++ b/init.el
@@ -490,11 +490,17 @@
 
 ;; Increase the default width of a new window.
 (when (display-graphic-p)
-  (add-hook 'after-init-hook
-            (lambda()
-              ;; The original size is 80x30.
-              (set-frame-size (selected-frame) 160 30)
-              nil))
+  (setq initial-frame-alist
+        '((top . 0)
+          ;; Start Emacs with the window snapped to the right edge.
+          (left . 1.0)
+          ;; The screen size should use the right half.
+          (width . 0.5)
+          ;; We use a value slightly smaller than 1.0. This is because even if `top`
+          ;; is set to 0.0 in macOS, the window is displayed slightly lower, and as a result,
+          ;; if `height` is set to 1.0, the bottom of the window becomes invisible.
+          (height . 0.9)
+          ))
   )
 
 (defun profiler-auto-start-and-report (duration-seconds)


### PR DESCRIPTION
- Configure initial frame position to the right edge.
- Resize the window size to the right half.