### PR TITLE
Do not bind C-@

### DIFF
--- a/init.el
+++ b/init.el
@@ -2266,7 +2266,7 @@ If the file is new, it will be populated with a default template."
               ;; vterm-copy-mode is mapped to C-c C-t originally but C-t is used as tmux prefix
               ;; key.
               ("\C-c [" . 'vterm-copy-mode) ; like tmux
-              ("\C-@" . 'my-vterm-toggle)
+              ("\C-c t" . 'my-vterm-toggle)
               ("<mouse-1>" . 'my-browse-url-at-point)
               ("\C-k" . 'my-vterm-kill-line)
               )
@@ -2336,7 +2336,7 @@ Optional argument ARGS ."
              (not vterm-toggle-fullscreen-p)))
         (vterm-toggle-show)))))
   :bind
-  ("\C-@" . 'my-vterm-toggle)
+  ("\C-c t" . 'my-vterm-toggle)
   ;; ("\C-c t" . 'vterm-toggle)
   ;; ("\C-c T" . 'vterm-toggle-cd)
   )


### PR DESCRIPTION
* Terminal emulators regard C-@ as C-space.
* If I bind C-@ with some interactive function, terminal emulator calls the function even if I type C-space.
* To avoid this confusing, change the keybind for vterm-toggle.
* Use C-c t for vterm-toggle. t means terminal and toggle.