### PR TITLE
Disable org headline font scaling in solarized theme

### DIFF
--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -92,6 +92,9 @@
 
 (use-package solarized-theme :ensure t
   :if (display-graphic-p)
+  :custom
+  (solarized-scale-org-headlines nil)
+  (solarized-scale-outline-headlines nil)
   :config
   (load-theme 'solarized-dark t)
   )


### PR DESCRIPTION
## Summary
- Disable `solarized-scale-org-headlines` and `solarized-scale-outline-headlines` in `solarized-theme` config
- This prevents org-mode headings from using different (larger) font sizes than body text

## Test plan
- [x] Restart Emacs and open an org file
- [x] Verify all heading levels (h1-h4+) use the same font size as body text

🤖 Generated with [Claude Code](https://claude.com/claude-code)