### PR TITLE
Load custom.el early so per-machine overrides take precedence

### DIFF
--- a/init.el
+++ b/init.el
@@ -36,6 +36,12 @@
 (require 'use-package)
 (setq use-package-always-ensure t)
 
+;; Load custom file early so per-machine overrides (e.g. org-directory) win
+;; over defaults set via use-package :custom in init-*.el.
+(let ((custom-file (expand-file-name "custom.el" user-emacs-directory)))
+  (when (file-exists-p custom-file)
+    (load custom-file)))
+
 ;; Load configuration files
 (require 'init-basic)
 (require 'init-ui)
@@ -47,11 +53,6 @@
 ;; Reset GC threshold to reasonable value after startup
 (setq gc-cons-threshold (* 2 1024 1024)  ; 2MB
       gc-cons-percentage 0.1)
-
-;; Load custom file if it exists
-(let ((custom-file (expand-file-name "custom.el" user-emacs-directory)))
-  (when (file-exists-p custom-file)
-    (load custom-file)))
 
 ;; Start server
 (unless (server-running-p)

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -16,12 +16,15 @@
   (setq org-jouornelly-file
    (expand-file-name
     "~/Library/Mobile Documents/iCloud~com~xenodium~Journelly/Documents/Journelly.org"))
+  ;; Only set the default when custom.el has not already provided one, so
+  ;; per-machine overrides via custom.el take precedence.
+  (unless (boundp 'org-directory)
+    (setq org-directory (expand-file-name "~/ghq/github.com/garaemon/org/")))
   :custom
   (org-startup-indented t)
   (org-hide-emphasis-markers t)
   (org-startup-with-latex-preview nil)
   (org-link-file-path-type 'relative)
-  (org-directory (expand-file-name "~/ghq/github.com/garaemon/org/"))
   ;; The special characters for org-capture-templates are described below:
   ;; https://orgmode.org/manual/Template-expansion.html#Template-expansion
   (org-capture-templates


### PR DESCRIPTION
## Per-machine customization in custom.el was being overwritten by defaults

`custom.el` was loaded after all `init-*.el` files, so any per-machine
customization of variables declared via `use-package :custom` (for
example `org-directory`) was immediately clobbered by the default value
set in the init file. In practice this made it impossible to point
Emacs at a different org directory on a particular machine via
`custom.el`.

## Load custom.el before init-*.el and make init-org.el defer to it

- `init.el`: move the `custom.el` load block to run right after
  `use-package` is required, before any `(require 'init-*)` call.
- `lisp/init-org.el`: only set the default `org-directory` when it has
  not already been bound (i.e. when `custom.el` did not provide one),
  and drop the `:custom` entry that unconditionally overwrote it.

This lets `custom.el` act as the authoritative per-machine override
while still giving fresh installs a sensible default.

## Verified locally

- `emacs --batch -l init.el -f batch-byte-compile init.el` completes
  without errors or warnings related to the change.

Generated with [Claude Code](https://claude.com/claude-code)