### PR TITLE
Disable org-document-title font scaling

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -255,6 +255,7 @@ Date format is YYYY-MM-DD.")
     (custom-set-faces `(org-level-6 ((t (:family ,default-font :inherit default)))))
     (custom-set-faces `(org-level-7 ((t (:family ,default-font :inherit default)))))
     (custom-set-faces `(org-level-8 ((t (:family ,default-font :inherit default)))))
+    (custom-set-faces `(org-document-title ((t (:family ,default-font :height 1.0 :weight bold :inherit default)))))
     )
 
   :bind (("C-c c" . 'org-capture)


### PR DESCRIPTION
## Align document title with flattened heading scale

Commit b7c4a50 disabled font scaling for `org-level-1` through `org-level-8`
so org headings render at the default font size. The document title face
(`org-document-title`) was left untouched, so it still scaled up under the
solarized theme and stood out relative to the flattened headings.

## Apply the same family/height override to org-document-title

Add a `custom-set-faces` entry for `org-document-title` alongside the
existing `org-level-N` entries, setting `:height 1.0` and the default font
family while keeping the bold weight.

Generated with [Claude Code](https://claude.com/claude-code)