### PR TITLE
Skip claude-code-ide session buffers from vterm-toggle

### DIFF
--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -1182,26 +1182,38 @@ Changes AFTER the selected commit are shown in the fringe (exclusive)."
   )
 
 (use-package multi-vterm :ensure t
-  :after (vterm)
-  :config
-  ;; Make a new vterm terminal from local computer
-  (defun vterm-local ()
-    (interactive)
-    (let ((default-directory (getenv "HOME")))
-      (multi-vterm)))
-  :bind (("C-M-t" . 'my-new-local-multi-vterm))
-  )
+  :after (vterm))
 
 (use-package vterm-toggle :ensure t
   :after (vterm)
   :config
-  ;; Overwrite vterm-toggle. If the vterm buffer is not focused, focus to the buffer.
+  ;; Hide claude-code-ide session buffers from vterm-toggle so that pressing the
+  ;; toggle key never lands on them. The session-buffer-p check fails for vterm
+  ;; buffers that have been renamed via `vterm-buffer-name-string', so also
+  ;; consult `claude-code-ide--processes' to identify them by process-buffer.
+  (defun my-vterm-toggle-claude-code-ide-buffer-p (buffer)
+    "Return non-nil when BUFFER hosts a claude-code-ide session."
+    (or (and (fboundp 'claude-code-ide--session-buffer-p)
+             (claude-code-ide--session-buffer-p buffer))
+        (and (boundp 'claude-code-ide--processes)
+             (cl-loop for proc being the hash-values of claude-code-ide--processes
+                      when (and (process-live-p proc)
+                                (eq (process-buffer proc) buffer))
+                      return t))))
+  (defun my-vterm-toggle-non-claude-code-ide-buffer-p (buffer)
+    "Return non-nil when BUFFER is not a claude-code-ide session buffer."
+    (not (my-vterm-toggle-claude-code-ide-buffer-p buffer)))
+  (add-to-list 'vterm-toggle-togglable-buffer-functions
+               #'my-vterm-toggle-non-claude-code-ide-buffer-p)
+  ;; Toggle to a non-claude vterm. When the user is currently inside a
+  ;; claude-code-ide buffer, do not hide it; instead pop up another vterm (or
+  ;; spawn a new one) so the claude-code-ide window stays out of the way.
   (defun my-vterm-toggle (&optional args)
-    "Vterm toggle.
-Optional argument ARGS ."
+    "Vterm toggle that ignores claude-code-ide session buffers.
+Optional argument ARGS is passed through as the prefix argument."
     (interactive "P")
     (cond
-     ((not (derived-mode-p 'vterm-mode))
+     ((my-vterm-toggle-claude-code-ide-buffer-p (current-buffer))
       (vterm-toggle-show))
      ((or (derived-mode-p 'vterm-mode)
           (and (vterm-toggle--get-window)


### PR DESCRIPTION
## C-c t no longer lands on claude-code-ide session vterm

`vterm-toggle` had no way to distinguish the claude-code-ide vterm from
ordinary vterm buffers, so pressing `C-c t` from outside a vterm could
pop up the Claude session window. Worse, pressing `C-c t` while inside
the Claude buffer hid it instead of switching away to a real vterm.

## Detect claude-code-ide buffers via the process registry

The session-buffer-p prefix check (`*claude-code[`) does not work once
`vterm-buffer-name-string` rewrites the buffer name (e.g. to
`*vterm: ✳ Claude Code*`). The new predicate also walks
`claude-code-ide--processes` and matches on `process-buffer`, which is
stable regardless of the displayed name.

The predicate is registered with
`vterm-toggle-togglable-buffer-functions`, so `vterm-toggle-show` skips
those buffers and falls back to creating a fresh vterm when the only
candidates are Claude sessions.

## Open another vterm instead of hiding when invoked inside Claude

`my-vterm-toggle` now special-cases the case where the current buffer
is a claude-code-ide session and calls `vterm-toggle-show` (which, with
the filter above, picks a non-Claude vterm or creates one) instead of
hiding the Claude window.

## Drop the broken C-M-t binding

`my-new-local-multi-vterm` was renamed to `vterm-local` long ago but
the `:bind` entry was never updated, leaving `C-M-t` pointing at an
undefined symbol. The binding wasn't being used, so the wrapper
function and its keybinding were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)