### PR TITLE
Add org-excalidraw via 4honor fork with SVG font workaround

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -9,6 +9,11 @@
 ;; Disable package.el in favor of manual control
 (setq package-enable-at-startup nil)
 
+;; Prefer the newer of .el / .elc when loading, so a forgotten stale .elc
+;; never overrides edits to the source. The default `nil' silently uses the
+;; older byte-compiled file (only warning), which has bitten us before.
+(setq load-prefer-newer t)
+
 ;; GC optimization for startup
 (setq gc-cons-threshold most-positive-fixnum
       gc-cons-percentage 0.6)

--- a/init.el
+++ b/init.el
@@ -67,20 +67,22 @@
  '(minuet-auto-suggestion-block-predicates '(minuet-evil-not-insert-state-p my-not-eolp) nil nil "Customized with use-package minuet")
  '(package-selected-packages
    '(aidermacs all-the-icons anzu auth-source-1password auto-highlight-symbol backup-each-save
-               base16-theme blamer bm browse-at-remote buffer-move calfw cape casual clang-format
-               cmake-mode coffee-mode corfu diff-hl docker dockerfile-mode elpy embark-consult
-               euslisp-mode expreg fill-column-indicator flycheck forge gcmh gist
+               base16-theme blamer bm browse-at-remote buffer-move buttercup calfw cape casual
+               clang-format cmake-mode coffee-mode corfu diff-hl docker dockerfile-mode elpy
+               embark-consult euslisp-mode expreg fill-column-indicator flycheck forge gcmh gist
                git-auto-commit-mode go-mode google-c-style google-this gptel graphviz-dot-mode hiwin
                hyde imenus jinja2-mode jinx json-mode lsp-sourcekit lsp-ui lua-mode marginalia
                minuet modern-cpp-font-lock multi-vterm multiple-cursors nix-mode nlinum ob-mermaid
-               orderless org-ai org-download org-faces org-modern org-roam outshine
+               orderless org-ai org-download org-excalidraw org-faces org-modern org-roam outshine
                persistent-scratch php-mode powerline protobuf-mode puppet-mode py-yapf qml-mode
                rainbow-delimiters recentf-ext rust-mode slack smart-cursor-color smart-mode-line
                smartrep solarized-theme sqlite3 sr-speedbar string-inflection swift-mode swiper
                switch-buffer-functions switch-window sx systemd terraform-mode thingopt total-lines
                transpose-frame treemacs-magit treesit-auto trr tsx-mode typescript-mode udev-mode
                undo-tree vertico-posframe volatile-highlights vterm-toggle vundo window-purpose
-               yaml-mode yasnippet-capf yatemplate)))
+               yaml-mode yasnippet-capf yatemplate))
+ '(package-vc-selected-packages
+   '((org-excalidraw :url "https://github.com/4honor/org-excalidraw.git"))))
 (custom-set-faces
  ;; custom-set-faces was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -43,12 +43,23 @@
       :prepend t
       :jump-to-captured nil
       )
+
      ))
   (org-todo-keywords '((sequence "TODO" "INPROGRESS" "|" "DONE" "DELEGATED" "CANCELLED")))
   ;; Use C-c C-q to insert tag.
   ;; To update the tag list from the agenda files, I set
   ;; `org-complete-tags-always-offer-all-agenda-tags' t.
   (org-complete-tags-always-offer-all-agenda-tags t)
+  ;; Required so that links using `:image-data-fun' (e.g. excalidraw: links
+  ;; provided by org-excalidraw) are rendered by `org-display-inline-images'.
+  ;; The default `skip' suppresses them entirely. Local SVGs are cheap to
+  ;; cache, so `cache' is safe even outside the org-excalidraw use case.
+  (org-display-remote-inline-images 'cache)
+  ;; Auto-display inline images when opening an org file. Must be set via
+  ;; `:custom' rather than in `org-mode-hook' because `org-mode' checks this
+  ;; variable before running mode hooks; setting it in the hook is too late
+  ;; for the buffer being opened.
+  (org-startup-with-inline-images t)
   :config
   (add-to-list 'org-agenda-files org-directory)
   (add-to-list 'org-agenda-files org-jouornelly-file)
@@ -269,8 +280,6 @@ Date format is YYYY-MM-DD.")
   :hook ((org-mode . (lambda ()
                        ;; To wrap texts
                        (visual-line-mode)
-                       ;; Show images inline automatically
-                       (setq org-startup-with-inline-images t)
                        ;; Enable only under org-directory
                        (when (and buffer-file-name
                                   (string-prefix-p org-directory
@@ -393,6 +402,76 @@ Date format is YYYY-MM-DD.")
   (org-babel-do-load-languages 'org-babel-load-languages org-babel-load-languages)
   :custom
   (ob-mermaid-cli-path (executable-find "mmdc"))
+  )
+
+;; 4honor/org-excalidraw is a fork rewritten for Org 9.7+. It ships its own
+;; `org-display-user-inline-images' advised onto `org-display-inline-images',
+;; so excalidraw: links are rendered without the upstream workaround that
+;; wdavew/org-excalidraw needs. It also generates the SVG thumbnail on demand
+;; instead of relying on file-notify, supports `kroki' as an alternative
+;; converter, and registers an `:export' handler.
+;;
+;; Requires excalidraw.com installed as a Chrome PWA so the OS can dispatch
+;; `.excalidraw' files via `open' / `xdg-open' for editing. The File Handling
+;; API is enabled by default since Chrome 102, so no chrome://flags toggle is
+;; needed; Chrome will prompt to grant the PWA permission on first open.
+(use-package org-excalidraw
+  :ensure nil
+  :after org
+  ;; Nothing in this block declares an autoload trigger, so without `:demand'
+  ;; the file would not load eagerly and its top-level `org-link-set-parameters'
+  ;; / `advice-add' would never register.
+  :demand t
+  :vc (:url "https://github.com/4honor/org-excalidraw.git" :rev :newest)
+  :init
+  ;; Used as a fallback converter when `kroki' is not installed.
+  (when (not (executable-find "excalidraw_export"))
+    (call-process-shell-command "npm install -g excalidraw_export"))
+  :custom
+  (org-excalidraw-default-directory (concat org-directory "excalidraw/"))
+  :config
+  (unless (file-directory-p org-excalidraw-default-directory)
+    (make-directory org-excalidraw-default-directory t))
+
+  ;; `excalidraw_export' 1.1.0 (latest, unmaintained since 2024) does not
+  ;; understand the modern Excalidraw font IDs that the current web UI
+  ;; assigns (5=Excalifont, 6=Nunito, 7=Lilita One, 8=Comic Shanns Mono).
+  ;; For text elements using those IDs it emits two broken attributes:
+  ;;   - font-family="Segoe UI Emoji" (a Windows-only font, missing on macOS)
+  ;;   - y="NaN"                       (text positioned at an invalid Y)
+  ;; Either alone is enough to make the text invisible. Patch both in the
+  ;; generated SVG: rewrite the font to Excalifont so drawings keep their
+  ;; hand-drawn look, and recover a baseline Y as 80% of the element's
+  ;; font-size on the same tag. Mixed-font drawings get unified to Excalifont,
+  ;; which is the dominant choice in Excalidraw and an acceptable trade-off
+  ;; for keeping the workaround simple.
+  ;;
+  ;; Excalifont install (macOS): download the woff2 from
+  ;;   https://plus.excalidraw.com/excalifont
+  ;; convert to ttf with the `woff2' Homebrew package (`brew install woff2',
+  ;; then `woff2_decompress Excalifont-Regular.woff2'), and install the
+  ;; resulting ttf via Font Book.
+  (defun my-org-excalidraw-svg-normalize-fonts (file &rest _)
+    "Repair font and Y attributes in FILE's generated SVG."
+    (let ((svg-path (org-excalidraw-svg-thumbnail-path (expand-file-name file))))
+      (when (file-exists-p svg-path)
+        (with-temp-buffer
+          (insert-file-contents svg-path)
+          (goto-char (point-min))
+          (while (search-forward "Segoe UI Emoji" nil t)
+            (replace-match "Excalifont" t t))
+          (goto-char (point-min))
+          (while (re-search-forward
+                  "y=\"NaN\"\\([^>]*?font-size=\"\\([0-9.]+\\)\\(?:px\\)?\"\\)"
+                  nil t)
+            (let* ((rest (match-string 1))
+                   (fsize (string-to-number (match-string 2)))
+                   (baseline (* fsize 0.8)))
+              (replace-match (format "y=\"%g\"%s" baseline rest) t t)))
+          (write-region (point-min) (point-max) svg-path nil 'silent)))))
+
+  (advice-add 'org-excalidraw-to-svg-thumbnail :after
+              #'my-org-excalidraw-svg-normalize-fonts)
   )
 
 (use-package org-roam


### PR DESCRIPTION
## Summary

- Install [4honor/org-excalidraw](https://github.com/4honor/org-excalidraw) via `package-vc` to render `excalidraw:` links inline in org-mode. The fork supplies its own advice on `org-display-inline-images` and is compatible with Org 9.7+, unlike wdavew/org-excalidraw whose `:image-data-fun` is ignored by modern Org.
- Flip `org-display-remote-inline-images` to `cache` (defaults to `skip` in Emacs 28+ which blocks every `:image-data-fun` link). Move `org-startup-with-inline-images` into `:custom` so it takes effect before `org-mode` evaluates startup options.
- Patch the SVG produced by the unmaintained `excalidraw_export` 1.1.0 via an `:after` advice: rewrite `font-family="Segoe UI Emoji"` to `Excalifont` and recover `y="NaN"` to 80% of the element's `font-size`, working around the CLI's lack of support for the modern font IDs Excalidraw assigns (5=Excalifont, 6=Nunito, 7=Lilita One, 8=Comic Shanns Mono).
- Set `load-prefer-newer` in `early-init.el` so a stale `.elc` never silently shadows edits to the source `.el`.

## Test plan

- [x] `emacs -batch -l init.el -f batch-byte-compile init.el` succeeds (CI)
- [x] `M-x org-excalidraw-create-drawing` creates a `.excalidraw` file and inserts an `excalidraw:` link
- [x] Opening the org buffer renders the link as an inline SVG with readable text using Excalifont
- [x] `Cmd+S` in Excalidraw PWA writes back to the source file, and the next `org-redisplay-inline-images` reflects the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)