### PR TITLE
Auto-revert dired buffers when their directory changes

### DIFF
--- a/lisp/init-editor.el
+++ b/lisp/init-editor.el
@@ -378,6 +378,7 @@ if ENV-SH indicates a remote path. Relies on the helper function
               ("M-s" . 'consult-grep)
               ("F" . 'magit-pull)
               ("b" . 'magit-branch))
+  :hook ('dired-mode-hook . 'auto-revert-mode)
   )
 
 (use-package wdired


### PR DESCRIPTION
## Summary

- Attach `auto-revert-mode` to `dired-mode-hook` so dired buffers refresh automatically when the underlying filesystem changes, eliminating the need to press `g` after creating, renaming, or deleting files outside of dired.

## Test plan

- [x] `emacs -batch -l init.el -f batch-byte-compile init.el` succeeds (CI)
- [x] Open a dired buffer, create a file outside of dired (`touch foo`), and verify the buffer refreshes without manual `g`

🤖 Generated with [Claude Code](https://claude.com/claude-code)