### PR TITLE
Auto-display ob-mermaid output without :file boilerplate

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -440,14 +440,14 @@ Date format is YYYY-MM-DD.")
   ;; that org-babel branch is skipped because it keys off `:file' in the
   ;; original params, so we must return the path ourselves to give
   ;; `org-babel-insert-result' something to link to.
-  (defun my-fill-ob-mermaid-file-param (orig-fn body params)
+  (defun my-fill-ob-mermaid-file-param (original-function body params)
     (let* ((existing-file (cdr (assq :file params)))
            (file (or existing-file
                      (my-derive-ob-mermaid-output-file body)))
            (augmented (if existing-file
                           params
                         (cons (cons :file file) params)))
-           (result (funcall orig-fn body augmented)))
+           (result (funcall original-function body augmented)))
       (or result (and (not existing-file) file))))
   (advice-add 'org-babel-execute:mermaid :around
               #'my-fill-ob-mermaid-file-param)

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -400,8 +400,63 @@ Date format is YYYY-MM-DD.")
   :config
   (add-to-list 'org-babel-load-languages '(mermaid . t))
   (org-babel-do-load-languages 'org-babel-load-languages org-babel-load-languages)
+
+  ;; Show freshly generated images after a src block runs so the user does not
+  ;; need to call `C-c C-x C-v' manually. The `refresh' arg replaces existing
+  ;; overlays so regenerated files (mermaid keeps the same path) actually show
+  ;; their new contents instead of the cached previous image.
+  (defun my-refresh-org-inline-images-after-babel ()
+    (when (derived-mode-p 'org-mode)
+      (org-display-inline-images nil t)))
+  (add-hook 'org-babel-after-execute-hook
+            #'my-refresh-org-inline-images-after-babel)
+
+  ;; Derive an output filename for mermaid blocks that omit `:file', so a bare
+  ;; `#+begin_src mermaid' still produces an image without per-block boilerplate.
+  ;; Uses the block's `#+NAME:' when present, otherwise a stable hash of the
+  ;; body so re-evaluating the same block reuses the same file.
+  (defun my-derive-ob-mermaid-output-file (body)
+    (let* ((info (org-babel-get-src-block-info t))
+           (block-name (nth 4 info))
+           (base (or block-name
+                     (format "mermaid-%s"
+                             (substring (secure-hash 'sha1 body) 0 12))))
+           (dir (expand-file-name
+                 "mermaid"
+                 (or (and buffer-file-name
+                          (file-name-directory buffer-file-name))
+                     default-directory))))
+      (unless (file-directory-p dir) (make-directory dir t))
+      (expand-file-name (concat base ".png") dir)))
+
+  ;; ob-mermaid's `org-babel-execute:mermaid' returns nil. When the user
+  ;; supplied `:file' explicitly, org-babel's own logic (see ob-core.el's
+  ;; `(setq result file)' branch) inserts the `#+RESULTS:' link to that
+  ;; file, so we keep the nil return — returning the path here would trip
+  ;; the sibling branch that overwrites `:file' with the result string,
+  ;; corrupting the freshly generated PNG.
+  ;;
+  ;; When `:file' was auto-derived (not present in the original params),
+  ;; that org-babel branch is skipped because it keys off `:file' in the
+  ;; original params, so we must return the path ourselves to give
+  ;; `org-babel-insert-result' something to link to.
+  (defun my-fill-ob-mermaid-file-param (orig-fn body params)
+    (let* ((existing-file (cdr (assq :file params)))
+           (file (or existing-file
+                     (my-derive-ob-mermaid-output-file body)))
+           (augmented (if existing-file
+                          params
+                        (cons (cons :file file) params)))
+           (result (funcall orig-fn body augmented)))
+      (or result (and (not existing-file) file))))
+  (advice-add 'org-babel-execute:mermaid :around
+              #'my-fill-ob-mermaid-file-param)
   :custom
   (ob-mermaid-cli-path (executable-find "mmdc"))
+  ;; Default to file-typed results so `:results file' can be omitted too. The
+  ;; advice above fills in `:file' automatically when not specified.
+  (org-babel-default-header-args:mermaid
+   '((:results . "file") (:exports . "results")))
   )
 
 ;; 4honor/org-excalidraw is a fork rewritten for Org 9.7+. It ships its own


### PR DESCRIPTION
## Make `#+begin_src mermaid` produce and display an image with no header arguments

Writing `:file foo.png :results file` on every mermaid block — and then
running `C-c C-x C-v` after each execute to actually see the PNG — adds
ceremony that has nothing to do with the diagram itself. After this
change, a bare `#+begin_src mermaid ... #+end_src` is enough: `C-c C-c`
runs `mmdc`, the `#+RESULTS:` link is inserted, and the image appears
inline.

## Auto-derive `:file` from `#+NAME:` or a body hash

`my-derive-ob-mermaid-output-file` picks the basename from the block's
`#+NAME:` when set so the file name stays stable as you edit, and falls
back to `mermaid-<sha1-12>.png` otherwise. Files land in a `mermaid/`
subdir next to the org file, created on demand.

## Refresh inline images on every babel execute

`org-display-inline-images nil t` runs from `org-babel-after-execute-hook`.
The `refresh` arg replaces overlays so a regenerated PNG (same path)
displays its new contents instead of the cached previous image.

## Work around ob-mermaid's `nil` return without corrupting user-supplied `:file`

`org-babel-execute:mermaid` returns `nil`, which would normally skip
`#+RESULTS:` insertion. The advice returns the resolved path only when
`:file` was auto-derived. When the user supplied `:file` explicitly the
advice still returns `nil` — otherwise ob-core's

```elisp
(with-temp-file file
  (insert (org-babel-format-result result ...)))
```

branch (ob-core.el:911-921) overwrites the freshly generated PNG with
the result string, producing a corrupted file.

## Verified manually

- [x] `#+begin_src mermaid` with no headers renders an inline PNG
- [x] `#+NAME: my-diagram` produces `mermaid/my-diagram.png`
- [x] Explicit `:file foo.png` still produces a valid PNG (no corruption)
- [x] Re-executing the same block updates the inline preview
- [x] `byte-compile-file lisp/init-org.el` passes

Generated with [Claude Code](https://claude.com/claude-code)