### PR TITLE
Add claude hook to remove .elc

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // empty' | { read -r cmd; case \"$cmd\" in *emacs*--batch*|*byte-compile*) git ls-files '*.el' | while IFS= read -r f; do [ -f \"${f}c\" ] && rm -f \"${f}c\"; done ;; esac; }"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
* If claude code uses emacs byte-compile, the hook automatically remvoes the generated .elc files.
* This is because emacs does not load elisp files correctly if there are .elc files.