### PR TITLE
Speed up org-agenda-quick and org-set-tags-command-quick

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,28 @@ Configuration is split into focused modules in the `lisp/` directory:
 - **init-utils.el**: Utility functions and helper tools
 
 Each module is loaded via `(require 'init-*)` in `init.el`.
+
+## Scripts
+
+Helper scripts kept under `scripts/`. They are not loaded automatically by Emacs; run them manually as described below.
+
+- **profile-org-agenda.el**: Batch-mode profiler for the same code path that `org-agenda-quick` triggers. Measures cold (no buffers preloaded) and warm (buffers reused) wall-clock time, then writes expanded CPU profile reports for both runs.
+
+  ```sh
+  /Applications/Emacs.app/Contents/MacOS/Emacs --batch \
+      -l init.el \
+      -l scripts/profile-org-agenda.el
+  ```
+
+  Outputs:
+  - `/tmp/org-agenda-profile-bench.txt` — per-phase wall-clock timings
+  - `/tmp/org-agenda-profile-cold.txt` — CPU profile, cold run
+  - `/tmp/org-agenda-profile-warm.txt` — CPU profile, warm run
+
+  Use this to spot which hooks or globalized minor modes dominate cold agenda time when adding new Org-related packages.
+
+- **latest_directory_timestamp.py**: Print the most recent modification timestamp under a directory tree.
+
+  ```sh
+  python scripts/latest_directory_timestamp.py <root-directory>
+  ```

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -297,33 +297,85 @@ Date format is YYYY-MM-DD.")
   :after (org)
   :config
 
-  (defmacro define-org-quick-command (new-func org-func)
+  (defmacro define-org-quick-command (new-func org-func &optional kill-new-buffers)
     `(defun ,new-func ()
-      ,(format "Call %s with large GC threshold and some modes disabled. It speeds up %s." org-func org-func)
+      ,(format "Call %s with Org features tuned for speed.
+
+Always disables: global watchers (auto-revert, jinx, treesit-auto,
+magit refresh, vc), Org startup actions (inline images, indent,
+LaTeX preview, folding), persistent element-cache I/O, and bumps
+the GC threshold.%s"
+               org-func
+               (if kill-new-buffers
+                   "
+
+Also disables per-file setup hooks (`org-mode-hook',
+`after-change-major-mode-hook', `find-file-hook') and dir-locals
+lookup for additional speed. Org buffers opened during this
+command (and not already visited beforehand) are killed afterwards
+so they get a fresh, fully configured setup the next time they are
+visited."
+                 "
+
+Per-file setup hooks (`org-mode-hook',
+`after-change-major-mode-hook', `find-file-hook') are left active
+because the caller (e.g. `org-agenda') stores markers into the
+buffers it opens, and the user will dereference them later (e.g.
+by clicking an agenda entry). Those buffers therefore need to be
+fully configured, not stripped down."))
       (interactive)
       (let ((started-at (float-time))
+            ,@(when kill-new-buffers
+                '((pre-existing-buffers (buffer-list))))
+            (auto-revert-was-on global-auto-revert-mode)
+            (jinx-was-on (and (boundp 'global-jinx-mode) global-jinx-mode))
+            (treesit-was-on (and (boundp 'global-treesit-auto-mode)
+                                 global-treesit-auto-mode))
             (gc-cons-threshold (* 500 1024 1024))
             (org-modules nil)
+            ,@(when kill-new-buffers
+                ;; These bindings strip a freshly opened buffer down to a
+                ;; bare org-mode shell. Safe only when we throw the buffer
+                ;; away afterwards; otherwise the user inherits a broken,
+                ;; feature-less buffer.
+                '((org-mode-hook nil)
+                  (after-change-major-mode-hook nil)
+                  (find-file-hook nil)
+                  (enable-dir-local-variables nil)))
+            (org-element-cache-persistent nil)
+            (org-inhibit-startup t)
+            (org-startup-with-inline-images nil)
+            (org-startup-indented nil)
+            (org-startup-with-latex-preview nil)
+            (org-startup-folded 'showall)
+            (org-agenda-inhibit-startup t)
             (magit-refresh-status-buffer nil)
             (magit-auto-revert-mode nil)
             (vc-handled-backends nil)
             (treesit-auto-langs nil))
-        (global-auto-revert-mode nil)
-        (global-jinx-mode nil)
-        (global-treesit-auto-mode nil)
+        (when auto-revert-was-on (global-auto-revert-mode -1))
+        (when jinx-was-on (global-jinx-mode -1))
+        (when treesit-was-on (global-treesit-auto-mode -1))
         (unwind-protect
-            (call-interactively ',org-func))
-        (global-auto-revert-mode)
-        (global-jinx-mode)
-        (global-treesit-auto-mode)
+            (call-interactively ',org-func)
+          ,@(when kill-new-buffers
+              '((dolist (buf (buffer-list))
+                  (when (and (not (memq buf pre-existing-buffers))
+                             (buffer-live-p buf)
+                             (buffer-file-name buf)
+                             (not (buffer-modified-p buf))
+                             (with-current-buffer buf
+                               (derived-mode-p 'org-mode)))
+                    (kill-buffer buf)))))
+          (when auto-revert-was-on (global-auto-revert-mode 1))
+          (when jinx-was-on (global-jinx-mode 1))
+          (when treesit-was-on (global-treesit-auto-mode 1)))
         (let* ((ended-at (float-time))
                (delta-duration (- ended-at started-at)))
-          (message "%s took %s sec" (symbol-name ',org-func) delta-duration)
-          )))
-    )
+          (message "%s took %s sec" (symbol-name ',org-func) delta-duration)))))
 
   (define-org-quick-command org-agenda-quick org-agenda)
-  (define-org-quick-command org-set-tags-command-quick org-set-tags-command)
+  (define-org-quick-command org-set-tags-command-quick org-set-tags-command t)
 
   :bind (("C-c a" . 'org-agenda-quick)
          ("C-c C-q" . 'org-set-tags-command-quick)

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -210,7 +210,24 @@ it from being deleted by `delete-other-windows` (C-x 1)."
       vundo-step-back
       vundo-step-forward
       ))
-  )
+  :config
+  ;; Pulsar runs `pulsar-resolve-function-aliases' every time
+  ;; `pulsar-mode' is enabled in a new buffer, and each invocation walks
+  ;; the entire obarray twice via `mapatoms'. With many agenda files
+  ;; this dominates the cost of opening Org buffers (82% of cold-path
+  ;; org-agenda time in profiling). The function only mutates the two
+  ;; global lists `pulsar-pulse-functions' and
+  ;; `pulsar-pulse-region-functions', so a single run per session is
+  ;; sufficient.
+  (defvar my-pulsar-resolve-done nil
+    "Non-nil after `pulsar-resolve-function-aliases' has run once.")
+  (defun my-pulsar-resolve-function-aliases-once (orig &rest args)
+    "Run ORIG only on the first call in this Emacs session."
+    (unless my-pulsar-resolve-done
+      (setq my-pulsar-resolve-done t)
+      (apply orig args)))
+  (advice-add 'pulsar-resolve-function-aliases
+              :around #'my-pulsar-resolve-function-aliases-once))
 
 ;;;; ============================================================
 ;;;; Window Layout Management

--- a/scripts/profile-org-agenda.el
+++ b/scripts/profile-org-agenda.el
@@ -1,0 +1,189 @@
+;;; profile-org-agenda.el --- Profile org-agenda-quick -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Batch-mode profiler for the same code path that
+;; `org-agenda-quick' triggers, so we can find what is still slow.
+;;
+;; Run with:
+;;   /Applications/Emacs.app/Contents/MacOS/Emacs --batch \
+;;     -l ~/.emacs.d/init.el \
+;;     -l scripts/profile-org-agenda.el
+;;
+;; Outputs:
+;;   /tmp/org-agenda-profile-bench.txt   per-phase wall-clock timings
+;;   /tmp/org-agenda-profile-cold.txt    CPU profile, cold run (no buffers)
+;;   /tmp/org-agenda-profile-warm.txt    CPU profile, warm run (buffers cached)
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'benchmark)
+(require 'profiler)
+(require 'org)
+(require 'org-agenda)
+
+(defvar profile-org-agenda-output-dir "/tmp"
+  "Directory where profile reports are written.")
+
+;; --- Helpers ---------------------------------------------------------------
+
+(defun profile-org-agenda--kill-org-buffers ()
+  "Kill every Org-mode buffer to simulate a cold run."
+  (let ((killed 0))
+    (dolist (buf (buffer-list))
+      (when (and (buffer-live-p buf)
+                 (buffer-file-name buf)
+                 (not (buffer-modified-p buf))
+                 (with-current-buffer buf (derived-mode-p 'org-mode)))
+        (kill-buffer buf)
+        (cl-incf killed)))
+    killed))
+
+(defmacro profile-org-agenda--with-quick-bindings (&rest body)
+  "Run BODY with the same suppressions as `define-org-quick-command'."
+  (declare (indent 0))
+  `(let ((gc-cons-threshold (* 500 1024 1024))
+         (org-modules nil)
+         (org-element-cache-persistent nil)
+         (org-inhibit-startup t)
+         (org-startup-with-inline-images nil)
+         (org-startup-indented nil)
+         (org-startup-with-latex-preview nil)
+         (org-startup-folded 'showall)
+         (org-agenda-inhibit-startup t)
+         (magit-refresh-status-buffer nil)
+         (magit-auto-revert-mode nil)
+         (vc-handled-backends nil)
+         (treesit-auto-langs nil))
+     ,@body))
+
+(defun profile-org-agenda--run-target ()
+  "Non-interactive equivalent of dispatching `a' in `org-agenda'."
+  (org-agenda-list nil))
+
+(defun profile-org-agenda--cleanup-report-buffers ()
+  "Kill any leftover profiler report buffers."
+  (dolist (buf (buffer-list))
+    (when (string-match-p "\\*[CM][PE][UM]-Profiler-Report"
+                          (buffer-name buf))
+      (kill-buffer buf))))
+
+(defun profile-org-agenda--save-report (path)
+  "Generate a fully expanded profiler report and write it to PATH.
+`profiler-report' does not return the buffer, so we locate it by
+name afterwards."
+  (profile-org-agenda--cleanup-report-buffers)
+  (profiler-report)
+  (let ((report-buf
+         (cl-find-if (lambda (buf)
+                       (string-prefix-p "*CPU-Profiler-Report"
+                                        (buffer-name buf)))
+                     (buffer-list))))
+    (unless report-buf
+      (error "No CPU profiler report buffer was created"))
+    (with-current-buffer report-buf
+      (goto-char (point-min))
+      ;; `profiler-report-expand-entry' with a non-nil arg expands the
+      ;; full subtree below the current line. Walking every line guarantees
+      ;; we cover branches that only appear after parent expansion.
+      (while (not (eobp))
+        (ignore-errors (profiler-report-expand-entry t))
+        (forward-line 1))
+      (let ((coding-system-for-write 'utf-8))
+        (write-region (point-min) (point-max) path nil 'silent)))
+    (kill-buffer report-buf)))
+
+(defun profile-org-agenda--format-bench (label result)
+  "Format LABEL and a `benchmark-run' RESULT triple."
+  (format "%-40s %.3fs total / %d GCs / %.3fs in GC"
+          label (nth 0 result) (nth 1 result) (nth 2 result)))
+
+;; --- Driver ----------------------------------------------------------------
+
+(defvar profile-org-agenda--bench-lines nil
+  "Accumulator for bench output, written to disk before profiling.")
+
+(defun profile-org-agenda--record-line (line)
+  "Record LINE in the bench accumulator and echo it."
+  (push line profile-org-agenda--bench-lines)
+  (message ">> %s" line))
+
+(defun profile-org-agenda--record-bench (label result)
+  "Record a `benchmark-run' RESULT under LABEL."
+  (profile-org-agenda--record-line
+   (profile-org-agenda--format-bench label result)))
+
+(defun profile-org-agenda-run ()
+  "Run the full benchmark + profile sweep."
+  (setq profile-org-agenda--bench-lines nil)
+
+  (let* ((files-bench
+          (benchmark-run 1
+            (profile-org-agenda--with-quick-bindings
+              (org-agenda-files))))
+         (n-files (length (org-agenda-files))))
+    (profile-org-agenda--record-line (format "agenda files: %d" n-files))
+    (profile-org-agenda--record-bench "(org-agenda-files)" files-bench))
+
+  (let ((killed (profile-org-agenda--kill-org-buffers)))
+    (profile-org-agenda--record-line
+     (format "killed %d preloaded org buffer(s) before cold run" killed)))
+
+  (let ((cold-bench
+         (benchmark-run 1
+           (profile-org-agenda--with-quick-bindings
+             (profile-org-agenda--run-target)))))
+    (profile-org-agenda--record-bench "agenda cold (no buffers)" cold-bench))
+
+  (let ((warm-bench
+         (benchmark-run 1
+           (profile-org-agenda--with-quick-bindings
+             (profile-org-agenda--run-target)))))
+    (profile-org-agenda--record-bench "agenda warm (buffers reused)" warm-bench))
+
+  ;; Persist bench summary up-front so it survives a later crash.
+  (let* ((bench-text (mapconcat #'identity
+                                (nreverse profile-org-agenda--bench-lines)
+                                "\n"))
+         (bench-path (expand-file-name "org-agenda-profile-bench.txt"
+                                       profile-org-agenda-output-dir)))
+    (with-temp-file bench-path (insert bench-text "\n"))
+    (message "\n=== Bench summary ===\n%s\n" bench-text)
+    (message "Wrote bench to %s" bench-path))
+
+    ;; CPU profile: cold
+    (message ">> profiling cold run...")
+    (profile-org-agenda--kill-org-buffers)
+    (garbage-collect)
+    (profiler-reset)
+    (profiler-start 'cpu)
+    (profile-org-agenda--with-quick-bindings
+      (profile-org-agenda--run-target))
+    (profiler-stop)
+    (profile-org-agenda--save-report
+     (expand-file-name "org-agenda-profile-cold.txt"
+                       profile-org-agenda-output-dir))
+    (message ">> wrote cold CPU profile")
+
+    ;; CPU profile: warm
+    (message ">> profiling warm run...")
+    (garbage-collect)
+    (profiler-reset)
+    (profiler-start 'cpu)
+    (profile-org-agenda--with-quick-bindings
+      (profile-org-agenda--run-target))
+    (profiler-stop)
+    (profile-org-agenda--save-report
+     (expand-file-name "org-agenda-profile-warm.txt"
+                       profile-org-agenda-output-dir))
+    (message ">> wrote warm CPU profile"))
+
+;; Suppress interactive tramp prompts that init.el triggers.
+(advice-add 'yes-or-no-p :override (lambda (&rest _) t))
+(advice-add 'y-or-n-p :override (lambda (&rest _) t))
+
+(profile-org-agenda-run)
+(kill-emacs 0)
+
+(provide 'profile-org-agenda)
+;;; profile-org-agenda.el ends here


### PR DESCRIPTION
## Summary
- Memoize `pulsar-resolve-function-aliases`: it was the dominant cost (82%) of cold `org-agenda-quick`, running `mapatoms` twice per opened agenda file (~176 files). The function only mutates two global lists, so a single run per session is enough.
- Reshape `define-org-quick-command` so the hook / dir-locals suppressions only kick in for the variant that throws its buffers away (`org-set-tags-command-quick`). `org-agenda-quick` now keeps `org-mode-hook`, `after-change-major-mode-hook`, and `find-file-hook` active, so buffers reached from agenda entries stay fully configured (org-modern, pulsar, org-indent, …).
- Fix two latent bugs in the wrapper macro: it was toggling instead of disabling `global-{auto-revert,jinx,treesit-auto}-mode` (Lisp-call semantics), and the `unwind-protect` cleanup forms sat outside the cleanup section so `C-g` left those modes disabled.
- Add `scripts/profile-org-agenda.el`, the batch-mode profiler used to track this down, and a README section pointing to it.

Cold path on this machine: **41.5s → 3.55s (11.7x)**, while buffers opened from the agenda dispatch are fully featured again.

## Test plan
- [x] `C-c a a` (`org-agenda-quick`): completes in a few seconds; agenda entries clickable into fully-configured org buffers (pulsar/org-modern visible).
- [x] `C-c C-q` (`org-set-tags-command-quick`) in an org buffer: tag completion fast, no lingering stripped-down buffers afterwards.
- [ ] Re-run the profiler to confirm timings:
  ```
  /Applications/Emacs.app/Contents/MacOS/Emacs --batch -l init.el -l scripts/profile-org-agenda.el
  cat /tmp/org-agenda-profile-bench.txt
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)