### PR TITLE
Add GitHub PR review workflow with side-by-side ediff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ custom.el
 annotations
 
 .gptel/
+code-review-error.log

--- a/lisp/init-editor.el
+++ b/lisp/init-editor.el
@@ -17,6 +17,12 @@
 ;;; Show ediff with horizontal split view
 (setq ediff-split-window-function 'split-window-horizontally)
 
+;; Use plain windows instead of ediff's separate control frame so the
+;; control buffer is just a thin strip.  `my-magit-ediff' and its review
+;; layer rely on this: they hide side windows and drive navigation from the
+;; revision buffers, which a separate control frame would break.
+(setq ediff-window-setup-function #'ediff-setup-windows-plain)
+
 ;; Insert closing parenthesis and quotes automatically
 (use-package elec-pair
   :ensure nil

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -871,8 +871,26 @@ Is Ollama running? (ollama serve) Status: %s" status))
   (forge-owned-accounts '(("garaemon")))
   :bind (("C-c M r" . my-diff-hl-review-enable)
          ("C-c M s" . my-diff-hl-review-disable)
-         ("C-c M d" . my-diff-hl-set-reference))
+         ("C-c M d" . my-diff-hl-set-reference)
+         ("C-c M e" . my-forge-ediff-pullreq-at-point)
+         ("C-c M c" . my-forge-ediff-review-add-comment)
+         ("C-c M l" . my-forge-ediff-review-list-comments)
+         ("C-c M C" . my-forge-ediff-review-submit))
   :config
+  (require 'my-forge-ediff-review)
+
+  (defun my-forge-ediff-pullreq-at-point ()
+    "Open the forge PR at point in a side-by-side ediff review session.
+Compares the PR's base commit against its head commit and lets you
+collect inline comments via `my-forge-ediff-review-add-comment'."
+    (interactive)
+    (let ((pullreq (or (forge-pullreq-at-point)
+                       (and (fboundp 'forge-current-topic)
+                            (forge-current-topic)))))
+      (unless (and pullreq (forge-pullreq-p pullreq))
+        (user-error "No forge pull request at point"))
+      (my-forge-ediff-review-start pullreq)))
+
   (defun my-forge-create-pullreq ()
     (interactive)
     (call-interactively 'forge-create-pullreq)
@@ -1026,6 +1044,44 @@ Changes AFTER the selected commit are shown in the fringe (exclusive)."
         (user-error "No commit at point"))
       (my-diff-hl--apply-revision commit)))
   )
+
+;; GitHub PR reviews from inside Emacs.
+;; Uses the doomelpa fork because the upstream wandersoncferreira/code-review
+;; has been largely inactive; doomelpa carries fixes for current forge/ghub.
+;;
+;; Auth reuses the same ~/.authinfo entry that forge uses (api.github.com login
+;; <user>^forge). No additional setup required when forge already works.
+;;
+;; Usage:
+;;   - From a forge topic buffer (e.g. magit-status PR list, RET on a PR),
+;;     press `C-c M v` to open the PR in code-review.
+;;   - Or `M-x code-review-start` and paste a PR URL.
+;;   - Inside the review buffer:
+;;       RET on a hunk -> add an inline comment
+;;       r            -> transient menu (approve / request-changes / comment)
+;;     For a side-by-side view of a single hunk, split the window
+;;     horizontally (`C-x 3`) and visit the file with `magit-diff-visit-file`
+;;     in the other window; comments stay in the code-review buffer.
+(use-package code-review
+  :vc (:url "https://github.com/doomelpa/code-review.git" :rev :newest)
+  :after forge
+  :bind (("C-c M v" . code-review-forge-pr-at-point))
+  :custom
+  ;; Open the review buffer in the other window so the source file stays
+  ;; visible side-by-side with the diff/comments.
+  (code-review-new-buffer-window-strategy #'switch-to-buffer-other-window)
+  ;; Reuse forge's auth-source entry (api.github.com login <user>^forge).
+  (code-review-auth-login-marker 'forge)
+  :config
+  ;; ghub 5.0 moved `ghub-graphql' (and friends) out of `ghub' into
+  ;; `ghub-legacy', which is not autoloaded.  code-review still calls the
+  ;; legacy names, so without this require every PR fetch fails with
+  ;; "deferred error: (wrong-type-argument listp void-function)".
+  (require 'ghub-legacy)
+  ;; Disable flyspell in the comment editor; it fights with code identifiers.
+  (add-hook 'code-review-comment-mode-hook
+            (lambda () (when (bound-and-true-p flyspell-mode)
+                         (flyspell-mode -1)))))
 
 (use-package git-commit
   :ensure nil

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -1,0 +1,363 @@
+;;; my-forge-ediff-review.el --- Comment on GitHub PRs from ediff -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Companion to `my-magit-ediff' for reviewing forge pull requests in a
+;; true side-by-side view.  While walking through hunks in ediff, capture
+;; per-line comments against the PR's head commit, then submit them as a
+;; single GitHub PR review (event = COMMENT / APPROVE / REQUEST_CHANGES).
+;;
+;; Workflow:
+;;   1. `my-forge-ediff-review-start' on a `forge-pullreq' (called by
+;;      `my-forge-ediff-pullreq-at-point').  Records the PR context and
+;;      launches `my-magit-ediff-all-compare' between base and head.
+;;   2. In any ediff revision buffer, `my-forge-ediff-review-add-comment'
+;;      grabs the current file/line/side from the buffer locals set by
+;;      `my-magit-ediff--create-revision-buffer' and pops up a comment
+;;      editor (markdown-mode, `C-c C-c' to save, `C-c C-k' to cancel).
+;;   3. `my-forge-ediff-review-list-comments' shows pending comments.
+;;   4. `my-forge-ediff-review-submit' POSTs them all as one review via
+;;      ghub against /repos/<owner>/<repo>/pulls/<num>/reviews.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'ghub)
+(require 'my-magit-ediff)
+
+(defvar my-forge-ediff-review--session nil
+  "Plist for the active review session, or nil.
+Keys: :owner :repo :num :head-rev :base-rev :host :comments.
+Each comment is a plist with :path :line :side :body.")
+
+;;;; Session lifecycle
+
+;; TODO(agent): The ediff control window is tiny and hard to use during
+;; reviews.  Drive multi-file navigation (next/prev hunk, next/prev file,
+;; quit) from the revision buffers directly so the control frame can be
+;; hidden or replaced with a thin header line.  Look at
+;; `ediff-window-setup-function' and `ediff-make-wide-display' for the
+;; entry points.
+(defun my-forge-ediff-review-start (pullreq)
+  "Start an ediff-based review session for forge PULLREQ.
+Verifies that the PR commits are fetched, records the session, and
+launches multi-file ediff between PR base and head."
+  (unless (forge-pullreq-p pullreq)
+    (user-error "Not a forge pull request"))
+  (let* ((repo (forge-get-repository pullreq))
+         (base-rev (oref pullreq base-rev))
+         (head-rev (oref pullreq head-rev)))
+    (unless (and base-rev (magit-rev-verify base-rev))
+      (user-error "PR base commit %s not fetched; run `forge-pull' first"
+                  (or base-rev "<unknown>")))
+    (unless (and head-rev (magit-rev-verify head-rev))
+      (user-error "PR head commit %s not fetched; run `forge-pull' first"
+                  (or head-rev "<unknown>")))
+    (when (and my-forge-ediff-review--session
+               (plist-get my-forge-ediff-review--session :comments)
+               (not (yes-or-no-p
+                     (format "Discard %d pending review comment(s)? "
+                             (length (plist-get my-forge-ediff-review--session
+                                                :comments))))))
+      (user-error "Aborted"))
+    (setq my-forge-ediff-review--session
+          (list :owner (oref repo owner)
+                :repo (oref repo name)
+                :num (oref pullreq number)
+                :head-rev head-rev
+                :base-rev base-rev
+                :host (my-forge-ediff-review--host-for repo)
+                :comments nil))
+    (message
+     "Review session for PR #%s started. C-c M c to comment, C-c M C to submit."
+     (oref pullreq number))
+    (my-magit-ediff-all-compare base-rev head-rev)))
+
+(defun my-forge-ediff-review--host-for (repo)
+  "Return the API host to use for REPO, or nil for ghub's default."
+  (when (and (fboundp 'forge-github-repository-p)
+             (forge-github-repository-p repo))
+    ;; nil makes ghub default to `ghub-default-host' which is api.github.com.
+    nil))
+
+(defun my-forge-ediff-review--ensure-session ()
+  "Signal an error if no review session is active."
+  (unless my-forge-ediff-review--session
+    (user-error "No active forge ediff review session")))
+
+;;;; Overlays in ediff buffers
+
+(defface my-forge-ediff-review-comment-face
+  '((((background light)) :background "#fff8c5" :foreground "#24292f")
+    (((background dark))  :background "#3a3a00" :foreground "#ffffff"))
+  "Face for lines with pending review comments and inline body display."
+  :group 'my-forge-ediff-review)
+
+(defun my-forge-ediff-review--side-for-rev (rev)
+  "Return \"LEFT\" / \"RIGHT\" for REV in the current session, or nil."
+  (let ((s my-forge-ediff-review--session))
+    (cond
+     ((equal rev (plist-get s :base-rev)) "LEFT")
+     ((equal rev (plist-get s :head-rev)) "RIGHT"))))
+
+(defun my-forge-ediff-review--format-overlay-body (body)
+  "Indent every line of BODY for inline overlay display."
+  (mapconcat (lambda (l) (concat "    | " l))
+             (split-string body "\n")
+             "\n"))
+
+(defun my-forge-ediff-review--put-overlay (buf line body)
+  "Append BODY as a highlighted after-string overlay below LINE in BUF.
+The commented source line is left untouched; only the comment text
+itself is highlighted.  The overlay is anchored at end-of-line so it
+does not shift `display-line-numbers-mode' or `nlinum-mode' counts."
+  (with-current-buffer buf
+    (save-excursion
+      (goto-char (point-min))
+      (forward-line (1- line))
+      (let* ((eol (line-end-position))
+             (ov (make-overlay eol eol nil t nil)))
+        (overlay-put ov 'my-forge-ediff-review t)
+        (overlay-put ov 'priority 100)
+        (overlay-put ov 'after-string
+                     (propertize
+                      (concat
+                       "\n"
+                       (my-forge-ediff-review--format-overlay-body body))
+                      'face 'my-forge-ediff-review-comment-face))))))
+
+(defun my-forge-ediff-review--clear-overlays (&optional buf)
+  "Remove all review overlays from BUF (defaults to current buffer)."
+  (with-current-buffer (or buf (current-buffer))
+    (remove-overlays (point-min) (point-max) 'my-forge-ediff-review t)))
+
+(defun my-forge-ediff-review--reapply-overlays ()
+  "Reapply overlays in current buffer for comments matching its file/side."
+  (when (and my-forge-ediff-review--session
+             my-magit-ediff--buf-file
+             my-magit-ediff--buf-rev)
+    (my-forge-ediff-review--clear-overlays)
+    (let* ((file my-magit-ediff--buf-file)
+           (rev  my-magit-ediff--buf-rev)
+           (side (my-forge-ediff-review--side-for-rev rev)))
+      (when side
+        (dolist (c (plist-get my-forge-ediff-review--session :comments))
+          (when (and (string= (plist-get c :path) file)
+                     (string= (plist-get c :side) side))
+            (my-forge-ediff-review--put-overlay
+             (current-buffer)
+             (plist-get c :line)
+             (plist-get c :body))))))))
+
+(defun my-forge-ediff-review--refresh-all-buffers ()
+  "Reapply overlays in every live ediff revision buffer of the session."
+  (dolist (buf my-magit-ediff--temp-buffers)
+    (when (buffer-live-p buf)
+      (with-current-buffer buf
+        (my-forge-ediff-review--reapply-overlays)))))
+
+;; Hook so that comments persist when ediff revisits a file.
+(add-hook 'ediff-prepare-buffer-hook
+          #'my-forge-ediff-review--reapply-overlays)
+
+;;;; Context detection
+
+(defun my-forge-ediff-review--current-context ()
+  "Return plist (:path :line :side) for point in current buffer, or nil.
+Side is \"LEFT\" when the buffer shows the PR base commit, \"RIGHT\"
+when it shows the head."
+  (when my-forge-ediff-review--session
+    (let ((file my-magit-ediff--buf-file)
+          (rev  my-magit-ediff--buf-rev)
+          (line (line-number-at-pos)))
+      (when (and file rev)
+        (let* ((s my-forge-ediff-review--session)
+               (side (cond
+                      ((equal rev (plist-get s :base-rev)) "LEFT")
+                      ((equal rev (plist-get s :head-rev)) "RIGHT"))))
+          (when side
+            (list :path file :line line :side side)))))))
+
+;;;; Adding comments
+
+(defvar my-forge-ediff-review--editor-ctx nil
+  "Buffer-local context plist while editing a comment.")
+
+;; TODO(agent): Bind RET in the ediff revision buffers to this command
+;; while a review session is active, so commenting is one keystroke.
+;; The buffers are read-only and RET is unbound there, so a buffer-local
+;; keymap set in `my-magit-ediff--create-revision-buffer' (only when a
+;; session exists) should be safe.
+(defun my-forge-ediff-review-add-comment ()
+  "Add a PR review comment for the line at point in this ediff buffer."
+  (interactive)
+  (my-forge-ediff-review--ensure-session)
+  (let ((ctx (my-forge-ediff-review--current-context)))
+    (unless ctx
+      (user-error
+       "Not in a review ediff revision buffer (no file/rev context)"))
+    (my-forge-ediff-review--open-editor ctx)))
+
+(defun my-forge-ediff-review--open-editor (ctx)
+  "Pop up an editor buffer for a comment described by CTX."
+  (let ((buf (generate-new-buffer "*forge-review-comment*")))
+    (with-current-buffer buf
+      (when (fboundp 'markdown-mode)
+        (markdown-mode))
+      (insert (format
+               "<!-- %s:%d (%s) — C-c C-c to save, C-c C-k to cancel. \
+HTML comments are stripped. -->\n\n"
+               (plist-get ctx :path)
+               (plist-get ctx :line)
+               (plist-get ctx :side)))
+      (setq-local my-forge-ediff-review--editor-ctx ctx)
+      (local-set-key (kbd "C-c C-c") #'my-forge-ediff-review--save-comment)
+      (local-set-key (kbd "C-c C-k") #'my-forge-ediff-review--cancel-comment)
+      (goto-char (point-max)))
+    (pop-to-buffer buf)))
+
+(defun my-forge-ediff-review--strip-html-comments (text)
+  "Remove `<!-- ... -->' blocks from TEXT."
+  (replace-regexp-in-string "<!--\\(.\\|\n\\)*?-->" "" text))
+
+(defun my-forge-ediff-review--save-comment ()
+  "Finalize the comment in the current editor buffer and store it."
+  (interactive)
+  (let* ((ctx my-forge-ediff-review--editor-ctx)
+         (raw (buffer-string))
+         (body (string-trim
+                (my-forge-ediff-review--strip-html-comments raw))))
+    (when (string-empty-p body)
+      (user-error "Comment body is empty"))
+    (unless my-forge-ediff-review--session
+      (user-error "Review session disappeared; not saving"))
+    (let ((comment (append ctx (list :body body))))
+      (setf (plist-get my-forge-ediff-review--session :comments)
+            (cons comment
+                  (plist-get my-forge-ediff-review--session :comments))))
+    (let ((buf (current-buffer)))
+      (quit-window)
+      (kill-buffer buf))
+    (my-forge-ediff-review--refresh-all-buffers)
+    (message "Comment saved (%d pending)."
+             (length (plist-get my-forge-ediff-review--session :comments)))))
+
+(defun my-forge-ediff-review--cancel-comment ()
+  "Discard the in-progress comment editor."
+  (interactive)
+  (let ((buf (current-buffer)))
+    (quit-window)
+    (kill-buffer buf))
+  (message "Comment cancelled."))
+
+;;;; Listing / discarding
+
+(defun my-forge-ediff-review-list-comments ()
+  "Show pending review comments in a dedicated buffer."
+  (interactive)
+  (my-forge-ediff-review--ensure-session)
+  (let* ((comments (reverse
+                    (plist-get my-forge-ediff-review--session :comments)))
+         (buf (get-buffer-create "*forge-review-pending*")))
+    (with-current-buffer buf
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (if (null comments)
+            (insert "No pending comments.\n")
+          (let ((i 0))
+            (dolist (c comments)
+              (setq i (1+ i))
+              (insert (format "[%d] %s:%d (%s)\n%s\n\n"
+                              i
+                              (plist-get c :path)
+                              (plist-get c :line)
+                              (plist-get c :side)
+                              (plist-get c :body))))))
+        (insert
+         (format "\n-- PR #%s — d <n> discard, s submit --\n"
+                 (plist-get my-forge-ediff-review--session :num))))
+      (special-mode)
+      (local-set-key "d" #'my-forge-ediff-review-discard-comment)
+      (local-set-key "s" #'my-forge-ediff-review-submit)
+      (local-set-key "g" #'my-forge-ediff-review-list-comments))
+    (pop-to-buffer buf)))
+
+(defun my-forge-ediff-review-discard-comment (n)
+  "Discard pending comment number N (1-based, as shown in the list)."
+  (interactive "nDiscard comment #: ")
+  (my-forge-ediff-review--ensure-session)
+  (let* ((comments (reverse
+                    (plist-get my-forge-ediff-review--session :comments)))
+         (len (length comments)))
+    (unless (and (>= n 1) (<= n len))
+      (user-error "Out of range (1..%d)" len))
+    (let* ((target (nth (1- n) comments))
+           (remaining (cl-remove target comments :count 1 :test #'eq)))
+      (setf (plist-get my-forge-ediff-review--session :comments)
+            (reverse remaining)))
+    (my-forge-ediff-review--refresh-all-buffers)
+    (message "Discarded comment #%d. %d pending." n
+             (length (plist-get my-forge-ediff-review--session :comments)))
+    (when (get-buffer "*forge-review-pending*")
+      (my-forge-ediff-review-list-comments))))
+
+;;;; Submit
+
+(defun my-forge-ediff-review--build-payload (event summary)
+  "Build the JSON payload for a PR review POST."
+  (let* ((s my-forge-ediff-review--session)
+         (comments (reverse (plist-get s :comments))))
+    `((commit_id . ,(plist-get s :head-rev))
+      (event    . ,event)
+      (body     . ,(or summary ""))
+      (comments . ,(vconcat
+                    (mapcar
+                     (lambda (c)
+                       `((path . ,(plist-get c :path))
+                         (line . ,(plist-get c :line))
+                         (side . ,(plist-get c :side))
+                         (body . ,(plist-get c :body))))
+                     comments))))))
+
+;; TODO(agent): Replace the `read-string' summary prompt with a dedicated
+;; markdown editor buffer (modeled on `my-forge-ediff-review--open-editor'
+;; for per-line comments).  Submission should happen when the user hits
+;; `C-c C-c' in that buffer, with `C-c C-k' to cancel.  The minibuffer is
+;; too small for any non-trivial review summary.
+(defun my-forge-ediff-review-submit (event &optional summary)
+  "Submit pending comments to GitHub as a PR review.
+EVENT is one of \"COMMENT\", \"APPROVE\", \"REQUEST_CHANGES\".
+SUMMARY is the optional top-level review body."
+  (interactive
+   (let ((event (completing-read
+                 "Event: " '("COMMENT" "APPROVE" "REQUEST_CHANGES")
+                 nil t nil nil "COMMENT")))
+     (list event (read-string "Top-level summary (optional): "))))
+  (my-forge-ediff-review--ensure-session)
+  (let* ((s my-forge-ediff-review--session)
+         (comments (plist-get s :comments))
+         (summary-trim (string-trim (or summary ""))))
+    (when (and (string= event "COMMENT")
+               (null comments)
+               (string-empty-p summary-trim))
+      (user-error "Nothing to submit"))
+    (ghub-post
+     (format "/repos/%s/%s/pulls/%s/reviews"
+             (plist-get s :owner)
+             (plist-get s :repo)
+             (plist-get s :num))
+     (my-forge-ediff-review--build-payload event summary-trim)
+     :auth 'forge
+     :host (plist-get s :host)
+     :callback (lambda (_value &rest _)
+                 (message "Review submitted: %s (%d comments)"
+                          event (length comments))
+                 (setf (plist-get my-forge-ediff-review--session :comments)
+                       nil)
+                 (my-forge-ediff-review--refresh-all-buffers)
+                 (when (get-buffer "*forge-review-pending*")
+                   (my-forge-ediff-review-list-comments)))
+     :errorback (lambda (err &rest _)
+                  (message "Review submission failed: %S" err)))))
+
+(provide 'my-forge-ediff-review)
+;;; my-forge-ediff-review.el ends here

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -29,14 +29,42 @@
 Keys: :owner :repo :num :head-rev :base-rev :host :comments.
 Each comment is a plist with :path :line :side :body.")
 
+;;;; Ediff control & navigation
+
+;; Avoid ediff's separate-frame control window; use plain windows so the
+;; control buffer is just a thin strip and the revision buffers can
+;; drive navigation themselves (see `--setup-revision-keys' below).
+(setq ediff-window-setup-function #'ediff-setup-windows-plain)
+
+(defun my-forge-ediff-review--in-control-buffer (cmd)
+  "Run CMD with `ediff-control-buffer' selected as the current buffer."
+  (let ((ctrl (and (boundp 'ediff-control-buffer) ediff-control-buffer)))
+    (unless (and ctrl (buffer-live-p ctrl))
+      (user-error "No active ediff control buffer"))
+    (with-current-buffer ctrl
+      (call-interactively cmd))))
+
+(defun my-forge-ediff-review-next-diff ()
+  "Jump to the next ediff difference from the current revision buffer."
+  (interactive)
+  (my-forge-ediff-review--in-control-buffer #'ediff-next-difference))
+
+(defun my-forge-ediff-review-prev-diff ()
+  "Jump to the previous ediff difference from the current revision buffer."
+  (interactive)
+  (my-forge-ediff-review--in-control-buffer #'ediff-previous-difference))
+
+(defun my-forge-ediff-review-quit-ediff ()
+  "End the current file's ediff session immediately."
+  (interactive)
+  (let ((ctrl (and (boundp 'ediff-control-buffer) ediff-control-buffer)))
+    (unless (and ctrl (buffer-live-p ctrl))
+      (user-error "No active ediff control buffer"))
+    (with-current-buffer ctrl
+      (ediff-really-quit nil))))
+
 ;;;; Session lifecycle
 
-;; TODO(agent): The ediff control window is tiny and hard to use during
-;; reviews.  Drive multi-file navigation (next/prev hunk, next/prev file,
-;; quit) from the revision buffers directly so the control frame can be
-;; hidden or replaced with a thin header line.  Look at
-;; `ediff-window-setup-function' and `ediff-make-wide-display' for the
-;; entry points.
 (defun my-forge-ediff-review-start (pullreq)
   "Start an ediff-based review session for forge PULLREQ.
 Verifies that the PR commits are fetched, records the session, and
@@ -155,9 +183,29 @@ does not shift `display-line-numbers-mode' or `nlinum-mode' counts."
       (with-current-buffer buf
         (my-forge-ediff-review--reapply-overlays)))))
 
-;; Hook so that comments persist when ediff revisits a file.
+(defun my-forge-ediff-review--setup-revision-keys ()
+  "Install buffer-local keys for in-place ediff navigation and commenting.
+Only active when a review session is running and the buffer has the
+file/rev locals set by `my-magit-ediff--create-revision-buffer'."
+  (when (and my-forge-ediff-review--session
+             my-magit-ediff--buf-file
+             my-magit-ediff--buf-rev)
+    (let ((map (make-composed-keymap nil (current-local-map))))
+      (define-key map (kbd "RET") #'my-forge-ediff-review-add-comment)
+      (define-key map (kbd "n") #'my-forge-ediff-review-next-diff)
+      (define-key map (kbd "p") #'my-forge-ediff-review-prev-diff)
+      (define-key map (kbd "q") #'my-forge-ediff-review-quit-ediff)
+      (use-local-map map))))
+
+(defun my-forge-ediff-review--prepare-buffer ()
+  "Apply overlays and install nav/comment keys in the current revision buffer."
+  (my-forge-ediff-review--reapply-overlays)
+  (my-forge-ediff-review--setup-revision-keys))
+
+;; Hook so that comments persist and review keys exist when ediff
+;; (re)visits a file.
 (add-hook 'ediff-prepare-buffer-hook
-          #'my-forge-ediff-review--reapply-overlays)
+          #'my-forge-ediff-review--prepare-buffer)
 
 ;;;; Context detection
 
@@ -182,11 +230,6 @@ when it shows the head."
 (defvar my-forge-ediff-review--editor-ctx nil
   "Buffer-local context plist while editing a comment.")
 
-;; TODO(agent): Bind RET in the ediff revision buffers to this command
-;; while a review session is active, so commenting is one keystroke.
-;; The buffers are read-only and RET is unbound there, so a buffer-local
-;; keymap set in `my-magit-ediff--create-revision-buffer' (only when a
-;; session exists) should be safe.
 (defun my-forge-ediff-review-add-comment ()
   "Add a PR review comment for the line at point in this ediff buffer."
   (interactive)
@@ -318,39 +361,83 @@ HTML comments are stripped. -->\n\n"
                          (body . ,(plist-get c :body))))
                      comments))))))
 
-;; TODO(agent): Replace the `read-string' summary prompt with a dedicated
-;; markdown editor buffer (modeled on `my-forge-ediff-review--open-editor'
-;; for per-line comments).  Submission should happen when the user hits
-;; `C-c C-c' in that buffer, with `C-c C-k' to cancel.  The minibuffer is
-;; too small for any non-trivial review summary.
-(defun my-forge-ediff-review-submit (event &optional summary)
-  "Submit pending comments to GitHub as a PR review.
-EVENT is one of \"COMMENT\", \"APPROVE\", \"REQUEST_CHANGES\".
-SUMMARY is the optional top-level review body."
-  (interactive
-   (let ((event (completing-read
-                 "Event: " '("COMMENT" "APPROVE" "REQUEST_CHANGES")
-                 nil t nil nil "COMMENT")))
-     (list event (read-string "Top-level summary (optional): "))))
+(defvar my-forge-ediff-review--summary-event nil
+  "Buffer-local: the event chosen for the summary editor.")
+
+(defun my-forge-ediff-review-submit ()
+  "Pick a review event then open a buffer to write the summary in.
+The actual POST happens when the user types `C-c C-c' in that buffer."
+  (interactive)
   (my-forge-ediff-review--ensure-session)
-  (let* ((s my-forge-ediff-review--session)
-         (comments (plist-get s :comments))
-         (summary-trim (string-trim (or summary ""))))
+  (let ((event (completing-read
+                "Event: " '("COMMENT" "APPROVE" "REQUEST_CHANGES")
+                nil t nil nil "COMMENT")))
+    (my-forge-ediff-review--open-summary-editor event)))
+
+(defun my-forge-ediff-review--open-summary-editor (event)
+  "Pop up a markdown buffer for the top-level review summary."
+  (let ((buf (generate-new-buffer "*forge-review-summary*"))
+        (pr-num (plist-get my-forge-ediff-review--session :num))
+        (pending (length
+                  (plist-get my-forge-ediff-review--session :comments))))
+    (with-current-buffer buf
+      (when (fboundp 'markdown-mode)
+        (markdown-mode))
+      (insert (format
+               "<!-- Review for PR #%s — event: %s — %d inline comment(s).\n\
+C-c C-c submits, C-c C-k cancels. HTML comments are stripped. -->\n\n"
+               pr-num event pending))
+      (setq-local my-forge-ediff-review--summary-event event)
+      (local-set-key (kbd "C-c C-c")
+                     #'my-forge-ediff-review--submit-from-editor)
+      (local-set-key (kbd "C-c C-k")
+                     #'my-forge-ediff-review--cancel-summary)
+      (goto-char (point-max)))
+    (pop-to-buffer buf)))
+
+(defun my-forge-ediff-review--submit-from-editor ()
+  "Finalize the summary in the current editor buffer and POST the review."
+  (interactive)
+  (my-forge-ediff-review--ensure-session)
+  (let* ((event my-forge-ediff-review--summary-event)
+         (raw (buffer-string))
+         (summary (string-trim
+                   (my-forge-ediff-review--strip-html-comments raw)))
+         (comments (plist-get my-forge-ediff-review--session :comments)))
+    (unless event
+      (user-error "No event recorded for this summary buffer"))
     (when (and (string= event "COMMENT")
                (null comments)
-               (string-empty-p summary-trim))
+               (string-empty-p summary))
       (user-error "Nothing to submit"))
+    (my-forge-ediff-review--do-submit event summary)
+    (let ((buf (current-buffer)))
+      (quit-window)
+      (kill-buffer buf))))
+
+(defun my-forge-ediff-review--cancel-summary ()
+  "Discard the summary editor without submitting."
+  (interactive)
+  (let ((buf (current-buffer)))
+    (quit-window)
+    (kill-buffer buf))
+  (message "Submission cancelled."))
+
+(defun my-forge-ediff-review--do-submit (event summary)
+  "POST EVENT/SUMMARY plus the session's pending inline comments via ghub."
+  (let* ((s my-forge-ediff-review--session)
+         (comment-count (length (plist-get s :comments))))
     (ghub-post
      (format "/repos/%s/%s/pulls/%s/reviews"
              (plist-get s :owner)
              (plist-get s :repo)
              (plist-get s :num))
-     (my-forge-ediff-review--build-payload event summary-trim)
+     (my-forge-ediff-review--build-payload event summary)
      :auth 'forge
      :host (plist-get s :host)
      :callback (lambda (_value &rest _)
                  (message "Review submitted: %s (%d comments)"
-                          event (length comments))
+                          event comment-count)
                  (setf (plist-get my-forge-ediff-review--session :comments)
                        nil)
                  (my-forge-ediff-review--refresh-all-buffers)

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -121,7 +121,11 @@ launches multi-file ediff between PR base and head."
     (my-magit-ediff-all-compare base-rev head-rev)))
 
 (defun my-forge-ediff-review--host-for (repo)
-  "Return the API host to use for REPO, or nil for ghub's default."
+  "Return the API host to use for REPO, or nil for ghub's default.
+Only github.com is supported for now: a GitHub repository resolves to
+nil, which makes ghub fall back to `ghub-default-host' (api.github.com)."
+  ;; TODO: support GitHub Enterprise by returning the repository's own API
+  ;; host (e.g. forge's `apihost' slot) instead of always nil.
   (when (and (fboundp 'forge-github-repository-p)
              (forge-github-repository-p repo))
     ;; nil makes ghub default to `ghub-default-host' which is api.github.com.

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -207,19 +207,26 @@ does not shift `display-line-numbers-mode' or `nlinum-mode' counts."
       (with-current-buffer buf
         (my-forge-ediff-review--reapply-overlays)))))
 
+(defvar-local my-forge-ediff-review--keys-installed nil
+  "Non-nil once review navigation keys are installed in this buffer.
+Guards against `ediff-prepare-buffer-hook' firing more than once on the
+same buffer and stacking composed keymaps on top of each other.")
+
 (defun my-forge-ediff-review--setup-revision-keys ()
   "Install buffer-local keys for in-place ediff navigation and commenting.
 Only active when a review session is running and the buffer has the
 file/rev locals set by `my-magit-ediff--create-revision-buffer'."
   (when (and my-forge-ediff-review--session
              my-magit-ediff--buf-file
-             my-magit-ediff--buf-rev)
+             my-magit-ediff--buf-rev
+             (not my-forge-ediff-review--keys-installed))
     (let ((map (make-composed-keymap nil (current-local-map))))
       (define-key map (kbd "RET") #'my-forge-ediff-review-add-comment)
       (define-key map (kbd "n") #'my-forge-ediff-review-next-diff)
       (define-key map (kbd "p") #'my-forge-ediff-review-prev-diff)
       (define-key map (kbd "q") #'my-forge-ediff-review-quit-ediff)
-      (use-local-map map))))
+      (use-local-map map)
+      (setq-local my-forge-ediff-review--keys-installed t))))
 
 (defun my-forge-ediff-review--prepare-buffer ()
   "Apply overlays and install nav/comment keys in the current revision buffer."

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -6,6 +6,28 @@
 ;; per-line comments against the PR's head commit, then submit them as a
 ;; single GitHub PR review (event = COMMENT / APPROVE / REQUEST_CHANGES).
 ;;
+;; Data model:
+;;   All review state lives in one global plist,
+;;   `my-forge-ediff-review--session' (nil when no review is active):
+;;
+;;     (:owner "..." :repo "..." :num N
+;;      :base-rev "<sha>" :head-rev "<sha>" :host nil
+;;      :comments (COMMENT ...))
+;;
+;;   Each pending comment is itself a plist:
+;;
+;;     (:path "rel/path" :line N :side "LEFT"|"RIGHT" :body "markdown")
+;;
+;;   :side is "LEFT" for the base commit and "RIGHT" for the head commit,
+;;   matching the GitHub Reviews API.  Where does (:path :line :side) come
+;;   from?  Ediff only shows two anonymous buffers, so each revision buffer
+;;   is tagged with the buffer locals `my-magit-ediff--buf-file' and
+;;   `my-magit-ediff--buf-rev' (set in `my-magit-ediff--create-revision-buffer').
+;;   `--current-context' reads those: :path = `--buf-file', :line = point's
+;;   line, and :side = `--buf-rev' compared against the session's base/head.
+;;   New comments are prepended to :comments and reversed back to insertion
+;;   order when listed or submitted.
+;;
 ;; Workflow:
 ;;   1. `my-forge-ediff-review-start' on a `forge-pullreq' (called by
 ;;      `my-forge-ediff-pullreq-at-point').  Records the PR context and
@@ -31,10 +53,8 @@ Each comment is a plist with :path :line :side :body.")
 
 ;;;; Ediff control & navigation
 
-;; Avoid ediff's separate-frame control window; use plain windows so the
-;; control buffer is just a thin strip and the revision buffers can
-;; drive navigation themselves (see `--setup-revision-keys' below).
-(setq ediff-window-setup-function #'ediff-setup-windows-plain)
+;; NOTE: `ediff-window-setup-function' is set to `ediff-setup-windows-plain'
+;; in init-editor.el; the in-buffer navigation below depends on it.
 
 (defun my-forge-ediff-review--in-control-buffer (cmd)
   "Run CMD with `ediff-control-buffer' selected as the current buffer."

--- a/lisp/my-magit-ediff.el
+++ b/lisp/my-magit-ediff.el
@@ -93,8 +93,28 @@
              file)
     (my-magit-ediff--open-file file)))
 
+;; Workaround for this config's `my-magit-status-side-window' (C-c L) in
+;; init-ui.el, which opens magit via `display-buffer-in-side-window'.
+;; That stamps the window with the `window-side' parameter, so when
+;; ediff (configured to use `ediff-setup-windows-plain' by
+;; my-forge-ediff-review) calls `delete-other-windows', Emacs refuses
+;; with "Cannot make side window the only window".  We hop to a regular
+;; window first so the plain setup can clear the frame normally.
+;; Non-side windows (e.g. `C-c l') skip this entirely.
+(defun my-magit-ediff--ensure-non-side-window ()
+  "Switch to a non-side window before launching ediff's plain setup."
+  (when (window-parameter (selected-window) 'window-side)
+    (let ((target (seq-find
+                   (lambda (w) (not (window-parameter w 'window-side)))
+                   (window-list nil 'no-mini))))
+      (if target
+          (select-window target)
+        ;; Only side windows remain; carve out a main area.
+        (select-window (split-window (frame-root-window) nil 'right))))))
+
 (defun my-magit-ediff--open-file (file)
   "Open ediff for a single FILE using current rev-a/rev-b."
+  (my-magit-ediff--ensure-non-side-window)
   (let ((buf-a (my-magit-ediff--create-revision-buffer
                 file my-magit-ediff--rev-a))
         (buf-b (my-magit-ediff--create-revision-buffer

--- a/lisp/my-magit-ediff.el
+++ b/lisp/my-magit-ediff.el
@@ -33,6 +33,12 @@
 (defvar my-magit-ediff--temp-buffers nil
   "Temporary revision buffers to kill on navigation or cleanup.")
 
+(defvar-local my-magit-ediff--buf-file nil
+  "Repository-relative path of the file shown in this revision buffer.")
+
+(defvar-local my-magit-ediff--buf-rev nil
+  "Git revision (commit SHA / `index' / nil) shown in this revision buffer.")
+
 ;;;; Entry point functions
 
 ;;;###autoload
@@ -103,7 +109,11 @@ If REV is a string, return that revision's content."
   (let ((default-directory (magit-toplevel)))
     (cond
      ((null rev)
-      (find-file-noselect (expand-file-name file)))
+      (let ((buf (find-file-noselect (expand-file-name file))))
+        (with-current-buffer buf
+          (setq-local my-magit-ediff--buf-file file
+                      my-magit-ediff--buf-rev nil))
+        buf))
      ((eq rev 'index)
       (let ((buf (generate-new-buffer
                   (format "%s (index)" file))))
@@ -112,6 +122,8 @@ If REV is a string, return that revision's content."
           (let ((buffer-file-name (expand-file-name file)))
             (set-auto-mode))
           (setq buffer-read-only t)
+          (setq-local my-magit-ediff--buf-file file
+                      my-magit-ediff--buf-rev 'index)
           (goto-char (point-min)))
         (push buf my-magit-ediff--temp-buffers)
         buf))
@@ -123,6 +135,8 @@ If REV is a string, return that revision's content."
           (let ((buffer-file-name (expand-file-name file)))
             (set-auto-mode))
           (setq buffer-read-only t)
+          (setq-local my-magit-ediff--buf-file file
+                      my-magit-ediff--buf-rev rev)
           (goto-char (point-min)))
         (push buf my-magit-ediff--temp-buffers)
         buf)))))

--- a/lisp/my-magit-ediff.el
+++ b/lisp/my-magit-ediff.el
@@ -33,6 +33,14 @@
 (defvar my-magit-ediff--temp-buffers nil
   "Temporary revision buffers to kill on navigation or cleanup.")
 
+;; These two buffer locals bridge this generic ediff engine and the
+;; `my-forge-ediff-review' layer.  Ediff itself only shows two anonymous
+;; buffers side by side; it has no notion of which file each buffer holds
+;; or which side (base vs head) it represents.  By stamping the file path
+;; and revision onto each revision buffer here, the review layer can derive
+;; the (path, line, side) a comment targets: `--buf-file' gives the path,
+;; and matching `--buf-rev' against the session's base-rev / head-rev gives
+;; the LEFT / RIGHT side required by the GitHub Reviews API.
 (defvar-local my-magit-ediff--buf-file nil
   "Repository-relative path of the file shown in this revision buffer.")
 

--- a/lisp/my-magit-ediff.el
+++ b/lisp/my-magit-ediff.el
@@ -39,6 +39,9 @@
 (defvar-local my-magit-ediff--buf-rev nil
   "Git revision (commit SHA / `index' / nil) shown in this revision buffer.")
 
+(defvar my-magit-ediff--saved-window-config nil
+  "Window configuration captured at session start, restored on cleanup.")
+
 ;;;; Entry point functions
 
 ;;;###autoload
@@ -80,7 +83,9 @@
         my-magit-ediff--rev-a rev-a
         my-magit-ediff--rev-b rev-b
         my-magit-ediff--total-count (length files)
-        my-magit-ediff--active t)
+        my-magit-ediff--active t
+        my-magit-ediff--saved-window-config (current-window-configuration))
+  (my-magit-ediff--hide-side-windows)
   (add-hook 'ediff-quit-hook #'my-magit-ediff--on-quit)
   (my-magit-ediff--open-current))
 
@@ -95,26 +100,20 @@
 
 ;; Workaround for this config's `my-magit-status-side-window' (C-c L) in
 ;; init-ui.el, which opens magit via `display-buffer-in-side-window'.
-;; That stamps the window with the `window-side' parameter, so when
-;; ediff (configured to use `ediff-setup-windows-plain' by
-;; my-forge-ediff-review) calls `delete-other-windows', Emacs refuses
-;; with "Cannot make side window the only window".  We hop to a regular
-;; window first so the plain setup can clear the frame normally.
-;; Non-side windows (e.g. `C-c l') skip this entirely.
-(defun my-magit-ediff--ensure-non-side-window ()
-  "Switch to a non-side window before launching ediff's plain setup."
-  (when (window-parameter (selected-window) 'window-side)
-    (let ((target (seq-find
-                   (lambda (w) (not (window-parameter w 'window-side)))
-                   (window-list nil 'no-mini))))
-      (if target
-          (select-window target)
-        ;; Only side windows remain; carve out a main area.
-        (select-window (split-window (frame-root-window) nil 'right))))))
+;; Side windows carry the `window-side' parameter, and ediff's plain
+;; window setup (`delete-other-windows' then `split-window') cannot
+;; operate while one is present -- it errors with "Cannot make side
+;; window the only window" / "Cannot split side window...".  Hiding the
+;; side windows for the duration of the review sidesteps both; the
+;; original layout is restored in `my-magit-ediff--cleanup'.  Frames
+;; without side windows are unaffected.
+(defun my-magit-ediff--hide-side-windows ()
+  "Hide any side windows so ediff can take over the whole frame."
+  (when (window-with-parameter 'window-side nil nil)
+    (window-toggle-side-windows)))
 
 (defun my-magit-ediff--open-file (file)
   "Open ediff for a single FILE using current rev-a/rev-b."
-  (my-magit-ediff--ensure-non-side-window)
   (let ((buf-a (my-magit-ediff--create-revision-buffer
                 file my-magit-ediff--rev-a))
         (buf-b (my-magit-ediff--create-revision-buffer
@@ -188,19 +187,30 @@ If REV is a string, return that revision's content."
       (push (format "[%d/%d] %s" (1+ i) total file) result)
       (setq i (1+ i)))))
 
+(defun my-magit-ediff--ordered-collection (candidates)
+  "Return a completion table over CANDIDATES that preserves their order.
+Stops completion frameworks like vertico from re-sorting by history
+or length, so files stay in their natural 1..N order."
+  (lambda (string pred action)
+    (if (eq action 'metadata)
+        '(metadata (display-sort-function . identity)
+                   (cycle-sort-function . identity))
+      (complete-with-action action candidates string pred))))
+
 (defun my-magit-ediff--prompt-navigation ()
-  "Show file list using `completing-read' for navigation."
+  "Show file list using `completing-read' for navigation.
+Candidates stay in strict 1..N order followed by the quit entry.  No
+default is passed because completion UIs (vertico) hoist the default
+candidate to the top, which scrambles the visual order."
   (let* ((idx my-magit-ediff--current-index)
          (total my-magit-ediff--total-count)
          (quit-label "[Done] Quit review")
          (file-labels (my-magit-ediff--build-file-labels))
          (candidates (append file-labels (list quit-label)))
-         (default (if (< (1+ idx) total)
-                      (nth (1+ idx) file-labels)
-                    quit-label))
          (selection (completing-read
                      (format "Ediff [%d/%d done]: " (1+ idx) total)
-                     candidates nil t nil nil default)))
+                     (my-magit-ediff--ordered-collection candidates)
+                     nil t nil nil)))
     (if (string= selection quit-label)
         (progn
           (my-magit-ediff--cleanup)
@@ -211,7 +221,7 @@ If REV is a string, return that revision's content."
           (my-magit-ediff--open-current))))))
 
 (defun my-magit-ediff--cleanup ()
-  "Reset state variables and remove hook."
+  "Reset state variables, restore windows, and remove hook."
   (my-magit-ediff--kill-temp-buffers)
   (setq my-magit-ediff--files nil
         my-magit-ediff--current-index 0
@@ -219,7 +229,10 @@ If REV is a string, return that revision's content."
         my-magit-ediff--rev-b nil
         my-magit-ediff--total-count 0
         my-magit-ediff--active nil)
-  (remove-hook 'ediff-quit-hook #'my-magit-ediff--on-quit))
+  (remove-hook 'ediff-quit-hook #'my-magit-ediff--on-quit)
+  (when my-magit-ediff--saved-window-config
+    (set-window-configuration my-magit-ediff--saved-window-config)
+    (setq my-magit-ediff--saved-window-config nil)))
 
 ;;;; Keybindings
 

--- a/lisp/my-magit-ediff.el
+++ b/lisp/my-magit-ediff.el
@@ -182,9 +182,16 @@ If REV is a string, return that revision's content."
     (run-at-time 0.1 nil #'my-magit-ediff--after-quit)))
 
 (defun my-magit-ediff--after-quit ()
-  "Kill temp buffers from previous session, then show navigation."
+  "Kill temp buffers from previous session, then show navigation.
+If the navigation prompt is aborted (e.g. `C-g'), run cleanup so the
+session state and `ediff-quit-hook' do not leak into later, unrelated
+ediff sessions."
   (my-magit-ediff--kill-temp-buffers)
-  (my-magit-ediff--prompt-navigation))
+  (condition-case nil
+      (my-magit-ediff--prompt-navigation)
+    (quit
+     (my-magit-ediff--cleanup)
+     (message "Review ended."))))
 
 (defun my-magit-ediff--build-file-labels ()
   "Build labeled file list for `completing-read'."


### PR DESCRIPTION
## Summary
In-Emacs GitHub PR review workflow that pairs a true side-by-side diff
(multi-file ediff between PR base and head) with inline comment
collection submitted as a single GitHub PR review.

- Installs `code-review` (doomelpa fork) via `:vc`, reusing forge's
  authinfo. Loads `ghub-legacy` explicitly so `ghub-graphql` keeps
  working after the ghub 5.0 split (otherwise PR fetch fails with
  `(wrong-type-argument listp void-function)`).
- Adds `lisp/my-forge-ediff-review.el`: starts an ediff session for the
  PR at point, collects per-line comments shown as overlays under the
  relevant line, and POSTs them via
  `/repos/:o/:r/pulls/:n/reviews` (`COMMENT` / `APPROVE` /
  `REQUEST_CHANGES`).
- Extends `my-magit-ediff` revision buffers with `--buf-file` /
  `--buf-rev` locals so the review layer can derive `(path, line, side)`.

## Key bindings (under `C-c M`)
- `e` — start side-by-side ediff review for the PR at point
- `c` — add a comment for the current line (also `RET` in a revision buffer)
- `l` — list pending comments (`*forge-review-pending*`)
- `C` — submit pending comments as a PR review
- `v` — open the same PR in `code-review` (unified diff)

Inside a revision buffer during a review: `n`/`p` move between hunks,
`q` ends the current file, `RET` comments on the current line. The
review summary is written in a dedicated `*forge-review-summary*`
markdown buffer (`C-c C-c` submits, `C-c C-k` cancels).

## UX / window handling
- Uses `ediff-setup-windows-plain` so the diff fills the frame instead
  of spawning a tiny control frame; navigation is driven from the
  revision buffers.
- Hides side windows (e.g. the left magit-status panel from this
  config's `my-magit-status-side-window`) for the duration of a review
  and restores the saved window configuration on exit, avoiding "Cannot
  make/split side window" errors.
- Inter-file picker stays in strict 1..N order (order-preserving
  completion table; no default arg, which completion UIs hoist).

## Notes / limitations
- GitHub only accepts comments on lines inside the diff hunks; out-of-hunk
  comments are rejected (422) and surfaced in `*Messages*`.
- Comment sessions live in memory only; unsent comments are lost if Emacs
  exits. No integration with `code-review`'s local draft DB.
- Multi-line (region) comments are not yet supported.

## Test plan
- [x] `emacs -batch -l init.el -f batch-byte-compile init.el` passes (matches CI)
- [x] All entry-point symbols resolve at runtime
- [x] Manual: start review with `C-c M e` from the side-window magit panel,
      step through files, add comments on both sides, submit
- [x] Confirm submitted review and inline comments appear on GitHub
- [x] Re-open the same PR to confirm overlays clear after submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)