### PR TITLE
Add review sidebar with done flags and memos to multi-file ediff

### DIFF
--- a/lisp/my-magit-ediff-test.el
+++ b/lisp/my-magit-ediff-test.el
@@ -1,0 +1,77 @@
+;;; my-magit-ediff-test.el --- Tests for my-magit-ediff -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; ERT tests for the pure data-model helpers of my-magit-ediff.
+;; These tests avoid ediff/window side effects and only exercise the
+;; reviewed-flag, memo, counting, line-formatting and summary helpers.
+
+;;; Code:
+
+(require 'ert)
+(require 'my-magit-ediff)
+
+(defun my-magit-ediff-test--reset-state ()
+  "Reset session state to a clean slate for a single test."
+  (setq my-magit-ediff--files '("a.el" "b.el" "c.el")
+        my-magit-ediff--total-count 3
+        my-magit-ediff--reviewed (make-hash-table :test 'equal)
+        my-magit-ediff--memos (make-hash-table :test 'equal)))
+
+(ert-deftest should_mark_file_reviewed_when_toggled ()
+  (my-magit-ediff-test--reset-state)
+  (my-magit-ediff--toggle-file-reviewed "a.el")
+  (should (my-magit-ediff--file-reviewed-p "a.el")))
+
+(ert-deftest should_unmark_file_when_toggled_twice ()
+  (my-magit-ediff-test--reset-state)
+  (my-magit-ediff--toggle-file-reviewed "a.el")
+  (my-magit-ediff--toggle-file-reviewed "a.el")
+  (should-not (my-magit-ediff--file-reviewed-p "a.el")))
+
+(ert-deftest should_store_and_return_memo ()
+  (my-magit-ediff-test--reset-state)
+  (my-magit-ediff--set-file-memo "a.el" "needs refactor")
+  (should (string= (my-magit-ediff--file-memo "a.el") "needs refactor")))
+
+(ert-deftest should_clear_memo_when_set_empty ()
+  (my-magit-ediff-test--reset-state)
+  (my-magit-ediff--set-file-memo "a.el" "temp note")
+  (my-magit-ediff--set-file-memo "a.el" "")
+  (should-not (my-magit-ediff--file-memo "a.el")))
+
+(ert-deftest should_count_reviewed_files ()
+  (my-magit-ediff-test--reset-state)
+  (my-magit-ediff--toggle-file-reviewed "a.el")
+  (my-magit-ediff--toggle-file-reviewed "c.el")
+  (should (= (my-magit-ediff--reviewed-count) 2)))
+
+(ert-deftest should_render_check_marker_for_reviewed_file ()
+  (my-magit-ediff-test--reset-state)
+  (my-magit-ediff--toggle-file-reviewed "a.el")
+  (should (string-match-p "\\[✓\\]"
+                          (my-magit-ediff--format-file-line "a.el" 0 0))))
+
+(ert-deftest should_render_empty_marker_for_unreviewed_file ()
+  (my-magit-ediff-test--reset-state)
+  (should (string-match-p "\\[ \\]"
+                          (my-magit-ediff--format-file-line "b.el" 1 0))))
+
+(ert-deftest should_render_memo_indicator_when_memo_present ()
+  (my-magit-ediff-test--reset-state)
+  (my-magit-ediff--set-file-memo "b.el" "note")
+  (should (string-match-p "✎"
+                          (my-magit-ediff--format-file-line "b.el" 1 0))))
+
+(ert-deftest should_attach_file_property_on_line ()
+  (my-magit-ediff-test--reset-state)
+  (let ((line (my-magit-ediff--format-file-line "c.el" 2 0)))
+    (should (string= (get-text-property 0 'my-magit-ediff-file line) "c.el"))))
+
+(ert-deftest should_include_memo_in_summary ()
+  (my-magit-ediff-test--reset-state)
+  (my-magit-ediff--set-file-memo "a.el" "important note")
+  (should (string-match-p "important note"
+                          (my-magit-ediff--build-summary-text))))
+
+(provide 'my-magit-ediff-test)
+;;; my-magit-ediff-test.el ends here

--- a/lisp/my-magit-ediff.el
+++ b/lisp/my-magit-ediff.el
@@ -33,6 +33,18 @@
 (defvar my-magit-ediff--temp-buffers nil
   "Temporary revision buffers to kill on navigation or cleanup.")
 
+(defvar my-magit-ediff--reviewed nil
+  "Hash table mapping a file to t when it has been marked reviewed.")
+
+(defvar my-magit-ediff--memos nil
+  "Hash table mapping a file to its memo string.")
+
+(defconst my-magit-ediff--sidebar-buffer-name "*Ediff Review*"
+  "Name of the buffer that hosts the review file-list sidebar.")
+
+(defconst my-magit-ediff--summary-buffer-name "*Ediff Review Summary*"
+  "Name of the buffer that shows the review summary on quit.")
+
 ;;;; Entry point functions
 
 ;;;###autoload
@@ -74,8 +86,11 @@
         my-magit-ediff--rev-a rev-a
         my-magit-ediff--rev-b rev-b
         my-magit-ediff--total-count (length files)
-        my-magit-ediff--active t)
+        my-magit-ediff--active t
+        my-magit-ediff--reviewed (make-hash-table :test 'equal)
+        my-magit-ediff--memos (make-hash-table :test 'equal))
   (add-hook 'ediff-quit-hook #'my-magit-ediff--on-quit)
+  (my-magit-ediff--show-sidebar)
   (my-magit-ediff--open-current))
 
 (defun my-magit-ediff--open-current ()
@@ -141,51 +156,202 @@ If REV is a string, return that revision's content."
     (run-at-time 0.1 nil #'my-magit-ediff--after-quit)))
 
 (defun my-magit-ediff--after-quit ()
-  "Kill temp buffers from previous session, then show navigation."
+  "Kill temp buffers from previous session, then refresh the sidebar."
   (my-magit-ediff--kill-temp-buffers)
-  (my-magit-ediff--prompt-navigation))
-
-(defun my-magit-ediff--build-file-labels ()
-  "Build labeled file list for `completing-read'."
-  (let ((total my-magit-ediff--total-count)
-        (result nil)
-        (i 0))
-    (dolist (file my-magit-ediff--files (nreverse result))
-      (push (format "[%d/%d] %s" (1+ i) total file) result)
-      (setq i (1+ i)))))
-
-(defun my-magit-ediff--prompt-navigation ()
-  "Show file list using `completing-read' for navigation."
-  (let* ((idx my-magit-ediff--current-index)
-         (total my-magit-ediff--total-count)
-         (quit-label "[Done] Quit review")
-         (file-labels (my-magit-ediff--build-file-labels))
-         (candidates (append file-labels (list quit-label)))
-         (default (if (< (1+ idx) total)
-                      (nth (1+ idx) file-labels)
-                    quit-label))
-         (selection (completing-read
-                     (format "Ediff [%d/%d done]: " (1+ idx) total)
-                     candidates nil t nil nil default)))
-    (if (string= selection quit-label)
-        (progn
-          (my-magit-ediff--cleanup)
-          (message "Review ended. %d/%d files reviewed." (1+ idx) total))
-      (let ((pos (seq-position file-labels selection #'string=)))
-        (when pos
-          (setq my-magit-ediff--current-index pos)
-          (my-magit-ediff--open-current))))))
+  (when my-magit-ediff--active
+    (my-magit-ediff--render-sidebar)
+    (let ((window (get-buffer-window my-magit-ediff--sidebar-buffer-name)))
+      (when (window-live-p window)
+        (select-window window)))))
 
 (defun my-magit-ediff--cleanup ()
-  "Reset state variables and remove hook."
+  "Reset state variables, remove hook and close the sidebar window."
   (my-magit-ediff--kill-temp-buffers)
+  (let ((window (get-buffer-window my-magit-ediff--sidebar-buffer-name)))
+    (when (window-live-p window)
+      (ignore-errors (delete-window window))))
+  (let ((buffer (get-buffer my-magit-ediff--sidebar-buffer-name)))
+    (when (buffer-live-p buffer)
+      (kill-buffer buffer)))
   (setq my-magit-ediff--files nil
         my-magit-ediff--current-index 0
         my-magit-ediff--rev-a nil
         my-magit-ediff--rev-b nil
         my-magit-ediff--total-count 0
-        my-magit-ediff--active nil)
+        my-magit-ediff--active nil
+        my-magit-ediff--reviewed nil
+        my-magit-ediff--memos nil)
   (remove-hook 'ediff-quit-hook #'my-magit-ediff--on-quit))
+
+;;;; Data model helpers
+
+(defun my-magit-ediff--file-reviewed-p (file)
+  "Return non-nil when FILE has been marked reviewed."
+  (and my-magit-ediff--reviewed
+       (gethash file my-magit-ediff--reviewed)))
+
+(defun my-magit-ediff--toggle-file-reviewed (file)
+  "Toggle the reviewed flag for FILE."
+  (if (my-magit-ediff--file-reviewed-p file)
+      (remhash file my-magit-ediff--reviewed)
+    (puthash file t my-magit-ediff--reviewed)))
+
+(defun my-magit-ediff--file-memo (file)
+  "Return the memo string stored for FILE, or nil when none."
+  (and my-magit-ediff--memos
+       (gethash file my-magit-ediff--memos)))
+
+(defun my-magit-ediff--set-file-memo (file memo)
+  "Store MEMO for FILE. An empty MEMO removes any existing memo."
+  (if (string-empty-p memo)
+      (remhash file my-magit-ediff--memos)
+    (puthash file memo my-magit-ediff--memos)))
+
+(defun my-magit-ediff--reviewed-count ()
+  "Return the number of files marked reviewed."
+  (if my-magit-ediff--reviewed
+      (hash-table-count my-magit-ediff--reviewed)
+    0))
+
+(defun my-magit-ediff--format-file-line (file index current-index)
+  "Return the sidebar display line for FILE at INDEX.
+CURRENT-INDEX marks the file currently shown in ediff so it can be
+highlighted.  The returned string carries FILE in the
+`my-magit-ediff-file' text property for click and RET handling."
+  (let* ((reviewed-marker (if (my-magit-ediff--file-reviewed-p file) "[✓]" "[ ]"))
+         (memo-marker (if (my-magit-ediff--file-memo file) " ✎" "  "))
+         (pointer (if (= index current-index) "▶ " "  "))
+         (line (format "%s%s%s %s" pointer reviewed-marker memo-marker file)))
+    (when (= index current-index)
+      (setq line (propertize line 'face 'highlight)))
+    (propertize line 'my-magit-ediff-file file)))
+
+(defun my-magit-ediff--build-summary-text ()
+  "Return a textual review summary covering reviewed state and memos."
+  (let ((lines (list (format "Ediff review summary — reviewed %d/%d\n"
+                             (my-magit-ediff--reviewed-count)
+                             my-magit-ediff--total-count))))
+    (dolist (file my-magit-ediff--files)
+      (let ((status (if (my-magit-ediff--file-reviewed-p file) "DONE" "TODO"))
+            (memo (my-magit-ediff--file-memo file)))
+        (push (format "[%s] %s" status file) lines)
+        (when memo
+          (push (format "        memo: %s" memo) lines))))
+    (concat (string-join (nreverse lines) "\n") "\n")))
+
+;;;; Sidebar rendering and commands
+
+(defun my-magit-ediff--render-sidebar ()
+  "Rebuild the contents of the review sidebar buffer."
+  (let ((buffer (get-buffer-create my-magit-ediff--sidebar-buffer-name))
+        (saved-line nil))
+    (with-current-buffer buffer
+      (unless (derived-mode-p 'my-magit-ediff-review-mode)
+        (my-magit-ediff-review-mode))
+      (setq saved-line (line-number-at-pos))
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert (propertize
+                 (format "Review  reviewed %d/%d\n\n"
+                         (my-magit-ediff--reviewed-count)
+                         my-magit-ediff--total-count)
+                 'face 'bold))
+        (let ((index 0))
+          (dolist (file my-magit-ediff--files)
+            (insert (my-magit-ediff--format-file-line
+                     file index my-magit-ediff--current-index)
+                    "\n")
+            (setq index (1+ index)))))
+      (goto-char (point-min))
+      (forward-line (1- saved-line)))))
+
+(defun my-magit-ediff--show-sidebar ()
+  "Display the review sidebar in a left side window."
+  (my-magit-ediff--render-sidebar)
+  (display-buffer-in-side-window
+   (get-buffer my-magit-ediff--sidebar-buffer-name)
+   '((side . left)
+     (window-width . 40)
+     (window-parameters . ((no-delete-other-windows . t))))))
+
+(defun my-magit-ediff--select-content-window ()
+  "Select a non-side window so ediff does not take over the sidebar."
+  (let ((window (or (window-with-parameter 'window-side nil)
+                    (get-largest-window nil nil t))))
+    (when (and window
+               (not (window-parameter window 'window-side)))
+      (select-window window))))
+
+(defun my-magit-ediff-review-open-file-at-point ()
+  "Open ediff for the file on the current sidebar line."
+  (interactive)
+  (let ((file (get-text-property (point) 'my-magit-ediff-file)))
+    (if (null file)
+        (message "No file on this line.")
+      (let ((index (seq-position my-magit-ediff--files file #'string=)))
+        (when index
+          (setq my-magit-ediff--current-index index)
+          (my-magit-ediff--select-content-window)
+          (my-magit-ediff--open-current)
+          (my-magit-ediff--render-sidebar))))))
+
+(defun my-magit-ediff-review-toggle-reviewed ()
+  "Toggle the reviewed flag for the file on the current sidebar line."
+  (interactive)
+  (let ((file (get-text-property (point) 'my-magit-ediff-file)))
+    (if (null file)
+        (message "No file on this line.")
+      (my-magit-ediff--toggle-file-reviewed file)
+      (my-magit-ediff--render-sidebar))))
+
+(defun my-magit-ediff-review-edit-memo ()
+  "Edit the memo for the file on the current sidebar line."
+  (interactive)
+  (let ((file (get-text-property (point) 'my-magit-ediff-file)))
+    (if (null file)
+        (message "No file on this line.")
+      (let ((memo (read-string (format "Memo for %s: " file)
+                               (my-magit-ediff--file-memo file))))
+        (my-magit-ediff--set-file-memo file memo)
+        (my-magit-ediff--render-sidebar)))))
+
+(defun my-magit-ediff-review-refresh ()
+  "Redraw the review sidebar."
+  (interactive)
+  (my-magit-ediff--render-sidebar))
+
+(defun my-magit-ediff-review-quit ()
+  "End the review, showing a summary buffer of reviewed state and memos."
+  (interactive)
+  (let ((summary (my-magit-ediff--build-summary-text))
+        (reviewed (my-magit-ediff--reviewed-count))
+        (total my-magit-ediff--total-count))
+    (my-magit-ediff--cleanup)
+    (with-current-buffer (get-buffer-create my-magit-ediff--summary-buffer-name)
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert summary))
+      (goto-char (point-min))
+      (view-mode 1))
+    (display-buffer my-magit-ediff--summary-buffer-name)
+    (message "Review ended. %d/%d files reviewed." reviewed total)))
+
+(defvar my-magit-ediff-review-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "RET") #'my-magit-ediff-review-open-file-at-point)
+    (define-key map (kbd "<mouse-1>") #'my-magit-ediff-review-open-file-at-point)
+    (define-key map (kbd "d") #'my-magit-ediff-review-toggle-reviewed)
+    (define-key map (kbd "m") #'my-magit-ediff-review-edit-memo)
+    (define-key map (kbd "g") #'my-magit-ediff-review-refresh)
+    (define-key map (kbd "n") #'next-line)
+    (define-key map (kbd "p") #'previous-line)
+    (define-key map (kbd "q") #'my-magit-ediff-review-quit)
+    map)
+  "Keymap for `my-magit-ediff-review-mode'.")
+
+(define-derived-mode my-magit-ediff-review-mode special-mode "EdiffReview"
+  "Major mode for the multi-file ediff review sidebar."
+  (setq truncate-lines t))
 
 ;;;; Keybindings
 


### PR DESCRIPTION
## A completing-read prompt made multi-file review hard to track

The multi-file ediff review in `lisp/my-magit-ediff.el` moved between
files with a `completing-read` prompt after each ediff session. That
gave no overview of the whole change set, no record of which files were
already reviewed, and no place to note observations that should not turn
into review comments.

## A persistent left sidebar, GitHub-style

The prompt is replaced by a left side window that lists every changed
file. Emacs side windows are not removed by `delete-other-windows`, so
the list stays visible while ediff reconfigures the main area.

The sidebar supports:

- `RET` / click: open ediff for the file on the line
- `d`: toggle a per-file reviewed flag (shown as `[✓]`)
- `m`: attach a local memo that never becomes a comment (shown as `✎`)
- `q`: end the review and pop a `*Ediff Review Summary*` buffer listing
  reviewed state and memos

Review state lives only for the session, as requested.

## Pure helpers covered by ERT

The reviewed-flag, memo, counting, line-formatting and summary helpers
are separated from the ediff/window code and verified by 10 ERT tests
in `lisp/my-magit-ediff-test.el`. Tests pass and the file byte-compiles
with no warnings.

Generated with [Claude Code](https://claude.com/claude-code)