### PR TITLE
Forge-pull tracked repos on first magit-status open

### DIFF
--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -908,7 +908,26 @@ collect inline comments via `my-forge-ediff-review-add-comment'."
     (when (ignore-errors (forge-get-repository :tracked))
       (forge-pull)))
   (advice-add 'magit-pull-from-upstream :after #'my-forge-pull-after-magit-pull)
-  (advice-add 'magit-pull-fropm-pushremote :after #'my-forge-pull-after-magit-pull)
+  (advice-add 'magit-pull-from-pushremote :after #'my-forge-pull-after-magit-pull)
+
+  ;; Forge does not refresh its data on its own, so opening magit-status shows
+  ;; stale (or empty) PR/issue sections until a manual `forge-pull'.  Pull once
+  ;; per repository per Emacs session the first time its status buffer is
+  ;; opened.  The pull is asynchronous and refreshes the buffer when it
+  ;; finishes, and the per-session guard keeps it from hammering the GitHub API.
+  (defvar my-forge--session-pulled-repos (make-hash-table :test 'equal)
+    "Repository roots already forge-pulled during this Emacs session.")
+
+  (defun my-forge-pull-once-per-session ()
+    "Run `forge-pull' the first time a tracked repository's status is shown."
+    (when (ignore-errors (forge-get-repository :tracked))
+      (let ((repository-root (magit-toplevel)))
+        (when (and repository-root
+                   (not (gethash repository-root my-forge--session-pulled-repos)))
+          (puthash repository-root t my-forge--session-pulled-repos)
+          (forge-pull)))))
+
+  (add-hook 'magit-status-mode-hook #'my-forge-pull-once-per-session)
 
   ;; PR review mode using diff-hl:
   ;;   Overrides `diff-hl-reference-revision' to show PR changes (vs base branch) in fringe.

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -855,6 +855,12 @@ Is Ollama running? (ollama serve) Status: %s" status))
 
 (use-package forge
   :after magit
+  ;; Demand-load forge as soon as magit loads.  The auto forge-pull hook below
+  ;; lives in this :config block, so forge must be loaded for the hook to be
+  ;; registered before the first magit-status buffer is created.  With plain
+  ;; :after (deferred) forge would not load until a forge command runs, so the
+  ;; hook would be missing on the first magit-status of the session.
+  :demand t
   :ensure t
   ;; How to setup forge:
   ;;   1. configure github.user by following command:


### PR DESCRIPTION
## magit-status showed no forge data until a manual forge-pull

Forge never refreshes its PR/issue data on its own, so opening
`magit-status` left the forge sections empty or stale until the user ran
`forge-pull` by hand. The existing auto-pull only fired on certain magit
pull commands, and one of its advices was attached to a misspelled
function name (`magit-pull-fropm-pushremote`) so it never ran at all.

## Pull once per repository per Emacs session on status open

A `magit-status-mode-hook` now runs `forge-pull` the first time a tracked
repository's status buffer is opened. A per-session hash table of
repository roots guards against repeated pulls, so the GitHub API is not
hammered on every refresh. The pull is asynchronous and refreshes the
buffer when it completes, so forge data appears without any manual step.

The push-remote pull advice typo is fixed in the same change
(`fropm` -> `from`) so pulling from the push remote also triggers
`forge-pull` as originally intended.

## No lazy-load for forge
Disable lazy-loading for forge to enable some hook functions without calling forge functions beforehand.

## Verified

- `lisp/init-prog.el` byte-compiles with no new warnings (only the
  pre-existing forward-reference notes shared by the sibling
  `my-forge-pull-after-magit-pull`).
- Behavior to confirm interactively: open `magit-status` in a tracked
  repo after restarting Emacs; the PR/issue sections populate after the
  async pull, and reopening status in the same session does not pull again.

Generated with [Claude Code](https://claude.com/claude-code)