### PR TITLE
Add review sidebar, memos and reviewed flags to forge PR ediff review

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,16 @@ jobs:
       uses: purcell/setup-emacs@master
       with:
         version: '30.1'
-    - name: Test init.el
+    - name: Byte-compile init.el
       run: emacs -batch -l init.el -f batch-byte-compile init.el
+    - name: Install test dependencies
+      run: |
+        emacs -Q --batch --eval '(progn (require (quote package)) (add-to-list (quote package-archives) (cons "melpa" "https://melpa.org/packages/") t) (add-to-list (quote package-archives) (cons "nongnu" "https://elpa.nongnu.org/nongnu/") t) (package-initialize) (package-refresh-contents) (dolist (pkg (quote (magit ghub))) (unless (package-installed-p pkg) (package-install pkg))))'
+    - name: Run ERT tests
+      run: |
+        emacs -Q --batch --eval '(progn (require (quote package)) (package-initialize))' \
+          -L lisp -l ert \
+          -l tests/my-forge-ediff-review-model-test.el \
+          -l tests/my-forge-ediff-review-test.el \
+          -l tests/my-magit-ediff-window-test.el \
+          -f ert-run-tests-batch-and-exit

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -874,6 +874,8 @@ Is Ollama running? (ollama serve) Status: %s" status))
          ("C-c M d" . my-diff-hl-set-reference)
          ("C-c M e" . my-forge-ediff-pullreq-at-point)
          ("C-c M c" . my-forge-ediff-review-add-comment)
+         ("C-c M m" . my-forge-ediff-review-add-memo)
+         ("C-c M f" . my-forge-ediff-review-toggle-reviewed)
          ("C-c M l" . my-forge-ediff-review-list-comments)
          ("C-c M C" . my-forge-ediff-review-submit))
   :config

--- a/lisp/my-forge-ediff-review-model-test.el
+++ b/lisp/my-forge-ediff-review-model-test.el
@@ -1,0 +1,132 @@
+;;; my-forge-ediff-review-model-test.el --- Tests for review model -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; ERT tests for the pure data-model helpers in
+;; `my-forge-ediff-review-model'.  These helpers have no dependency on
+;; magit/forge/ghub, so they can be exercised in batch with:
+;;
+;;   emacs -batch -L lisp -l lisp/my-forge-ediff-review-model-test.el \
+;;     -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+(require 'my-forge-ediff-review-model)
+
+;;;; Reviewed flag (per-file path set)
+
+(ert-deftest review-model-should-report-not-reviewed-when-absent ()
+  (should-not (my-forge-ediff-review-model-reviewed-p '() "a.el"))
+  (should-not (my-forge-ediff-review-model-reviewed-p '("b.el") "a.el")))
+
+(ert-deftest review-model-should-report-reviewed-when-present ()
+  (should (my-forge-ediff-review-model-reviewed-p '("a.el" "b.el") "a.el")))
+
+(ert-deftest review-model-toggle-should-add-missing-path ()
+  (should (equal '("a.el")
+                 (my-forge-ediff-review-model-toggle-reviewed '() "a.el"))))
+
+(ert-deftest review-model-toggle-should-remove-present-path ()
+  (should (equal '("b.el")
+                 (my-forge-ediff-review-model-toggle-reviewed
+                  '("a.el" "b.el") "a.el"))))
+
+(ert-deftest review-model-toggle-should-not-mutate-input ()
+  (let ((original '("a.el")))
+    (my-forge-ediff-review-model-toggle-reviewed original "b.el")
+    (should (equal '("a.el") original))))
+
+;;;; Entry lookup (comments and memos share this shape)
+
+(defun review-model-test--entry (path line side body)
+  "Build a test entry plist."
+  (list :path path :line line :side side :body body))
+
+(ert-deftest review-model-find-entry-should-match-path-line-side ()
+  (let* ((target (review-model-test--entry "a.el" 10 "RIGHT" "hi"))
+         (entries (list target
+                        (review-model-test--entry "a.el" 11 "RIGHT" "no")
+                        (review-model-test--entry "a.el" 10 "LEFT" "no"))))
+    (should (eq target
+               (my-forge-ediff-review-model-find-entry
+                entries "a.el" 10 "RIGHT")))))
+
+(ert-deftest review-model-find-entry-should-return-nil-when-absent ()
+  (should-not (my-forge-ediff-review-model-find-entry
+               (list (review-model-test--entry "a.el" 10 "RIGHT" "hi"))
+               "a.el" 99 "RIGHT")))
+
+(ert-deftest review-model-remove-entry-should-drop-only-target ()
+  (let* ((keep (review-model-test--entry "a.el" 11 "RIGHT" "keep"))
+         (drop (review-model-test--entry "a.el" 10 "RIGHT" "drop"))
+         (entries (list drop keep)))
+    (should (equal (list keep)
+                   (my-forge-ediff-review-model-remove-entry entries drop)))))
+
+;;;; Per-file counts and per-side filtering
+
+(ert-deftest review-model-count-for-file-should-count-both-sides ()
+  (let ((entries (list (review-model-test--entry "a.el" 1 "LEFT" "x")
+                       (review-model-test--entry "a.el" 2 "RIGHT" "y")
+                       (review-model-test--entry "b.el" 3 "RIGHT" "z"))))
+    (should (= 2 (my-forge-ediff-review-model-count-for-file entries "a.el")))
+    (should (= 1 (my-forge-ediff-review-model-count-for-file entries "b.el")))
+    (should (= 0 (my-forge-ediff-review-model-count-for-file entries "c.el")))))
+
+(ert-deftest review-model-entries-for-side-should-filter-path-and-side ()
+  (let* ((match (review-model-test--entry "a.el" 2 "RIGHT" "y"))
+         (entries (list (review-model-test--entry "a.el" 1 "LEFT" "x")
+                        match
+                        (review-model-test--entry "b.el" 2 "RIGHT" "z"))))
+    (should (equal (list match)
+                   (my-forge-ediff-review-model-entries-for-side
+                    entries "a.el" "RIGHT")))))
+
+;;;; Sidebar line formatting
+
+(ert-deftest review-model-format-line-should-mark-current-file ()
+  (let ((line (my-forge-ediff-review-model-format-file-line
+               "a.el" t nil 0 0)))
+    (should (string-prefix-p ">" line))))
+
+(ert-deftest review-model-format-line-should-not-mark-other-files ()
+  (let ((line (my-forge-ediff-review-model-format-file-line
+               "a.el" nil nil 0 0)))
+    (should-not (string-prefix-p ">" (string-trim-left line)))
+    (should (string-match-p "a.el" line))))
+
+(ert-deftest review-model-format-line-should-show-reviewed-checkbox ()
+  (should (string-match-p "\\[x\\]"
+                          (my-forge-ediff-review-model-format-file-line
+                           "a.el" nil t 0 0)))
+  (should (string-match-p "\\[ \\]"
+                          (my-forge-ediff-review-model-format-file-line
+                           "a.el" nil nil 0 0))))
+
+(ert-deftest review-model-format-line-should-show-counts-when-nonzero ()
+  (let ((line (my-forge-ediff-review-model-format-file-line
+               "a.el" nil nil 2 1)))
+    (should (string-match-p "2c" line))
+    (should (string-match-p "1m" line))))
+
+(ert-deftest review-model-format-line-should-hide-counts-when-zero ()
+  (let ((line (my-forge-ediff-review-model-format-file-line
+               "a.el" nil nil 0 0)))
+    (should-not (string-match-p "0c" line))
+    (should-not (string-match-p "0m" line))))
+
+;;;; GitHub review payload (memos must never reach this)
+
+(ert-deftest review-model-payload-should-build-comment-vector ()
+  (let* ((comments (list (review-model-test--entry "a.el" 10 "RIGHT" "body")))
+         (payload (my-forge-ediff-review-model-payload-comments comments)))
+    (should (vectorp payload))
+    (should (= 1 (length payload)))
+    (let ((c (aref payload 0)))
+      (should (equal "a.el" (alist-get 'path c)))
+      (should (= 10 (alist-get 'line c)))
+      (should (equal "RIGHT" (alist-get 'side c)))
+      (should (equal "body" (alist-get 'body c))))))
+
+(provide 'my-forge-ediff-review-model-test)
+;;; my-forge-ediff-review-model-test.el ends here

--- a/lisp/my-forge-ediff-review-model.el
+++ b/lisp/my-forge-ediff-review-model.el
@@ -1,0 +1,98 @@
+;;; my-forge-ediff-review-model.el --- Pure data model for ediff review -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Pure, side-effect-free helpers backing `my-forge-ediff-review'.  They
+;; operate only on plain Lisp values (lists of plists, lists of paths) and
+;; depend on nothing heavier than `cl-lib', so they can be unit-tested in
+;; batch without loading magit/forge/ghub.
+;;
+;; Two kinds of per-line "entry" share the same plist shape and helpers:
+;;   - review comments, which are submitted to GitHub, and
+;;   - memos, which stay local and are never submitted.
+;; Each entry is (:path "rel/path" :line N :side "LEFT"|"RIGHT" :body "...").
+;;
+;; The reviewed flag is tracked separately as a plain list of file paths.
+
+;;; Code:
+
+(require 'cl-lib)
+
+;;;; Reviewed flag
+
+(defun my-forge-ediff-review-model-reviewed-p (reviewed-paths path)
+  "Return non-nil when PATH appears in REVIEWED-PATHS."
+  (and (member path reviewed-paths) t))
+
+(defun my-forge-ediff-review-model-toggle-reviewed (reviewed-paths path)
+  "Return a new list like REVIEWED-PATHS with PATH toggled.
+PATH is removed when already present and added otherwise.  The input
+list is not modified."
+  (if (member path reviewed-paths)
+      (remove path reviewed-paths)
+    (cons path reviewed-paths)))
+
+;;;; Entry lookup (comments and memos)
+
+(defun my-forge-ediff-review-model-find-entry (entries path line side)
+  "Return the first entry in ENTRIES matching PATH, LINE and SIDE, or nil."
+  (cl-find-if
+   (lambda (entry)
+     (and (equal (plist-get entry :path) path)
+          (eql (plist-get entry :line) line)
+          (equal (plist-get entry :side) side)))
+   entries))
+
+(defun my-forge-ediff-review-model-remove-entry (entries entry)
+  "Return ENTRIES without ENTRY, comparing with `eq'."
+  (cl-remove entry entries :count 1 :test #'eq))
+
+(defun my-forge-ediff-review-model-count-for-file (entries path)
+  "Return how many entries in ENTRIES have :path equal to PATH, any side."
+  (cl-count-if (lambda (entry) (equal (plist-get entry :path) path))
+               entries))
+
+(defun my-forge-ediff-review-model-entries-for-side (entries path side)
+  "Return entries in ENTRIES whose :path is PATH and :side is SIDE."
+  (cl-remove-if-not
+   (lambda (entry)
+     (and (equal (plist-get entry :path) path)
+          (equal (plist-get entry :side) side)))
+   entries))
+
+;;;; Sidebar line formatting
+
+(defun my-forge-ediff-review-model--counts-suffix (comment-count memo-count)
+  "Return a trailing count string for COMMENT-COUNT and MEMO-COUNT.
+Empty when both are zero so untouched files stay visually quiet."
+  (if (and (zerop comment-count) (zerop memo-count))
+      ""
+    (format " [%dc/%dm]" comment-count memo-count)))
+
+(defun my-forge-ediff-review-model-format-file-line
+    (file current-p reviewed-p comment-count memo-count)
+  "Return the sidebar text line for FILE.
+CURRENT-P marks the file shown in ediff with a leading caret.
+REVIEWED-P selects the checkbox glyph.  COMMENT-COUNT and MEMO-COUNT are
+appended only when non-zero."
+  (let ((pointer (if current-p "> " "  "))
+        (checkbox (if reviewed-p "[x] " "[ ] ")))
+    (concat pointer checkbox file
+            (my-forge-ediff-review-model--counts-suffix
+             comment-count memo-count))))
+
+;;;; GitHub review payload
+
+(defun my-forge-ediff-review-model-payload-comments (comments)
+  "Return a vector of GitHub review comment alists built from COMMENTS.
+Memos are never passed here, so they cannot leak into a submission."
+  (vconcat
+   (mapcar
+    (lambda (comment)
+      `((path . ,(plist-get comment :path))
+        (line . ,(plist-get comment :line))
+        (side . ,(plist-get comment :side))
+        (body . ,(plist-get comment :body))))
+    comments)))
+
+(provide 'my-forge-ediff-review-model)
+;;; my-forge-ediff-review-model.el ends here

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -45,11 +45,14 @@
 (require 'cl-lib)
 (require 'ghub)
 (require 'my-magit-ediff)
+(require 'my-forge-ediff-review-model)
 
 (defvar my-forge-ediff-review--session nil
   "Plist for the active review session, or nil.
-Keys: :owner :repo :num :head-rev :base-rev :host :comments.
-Each comment is a plist with :path :line :side :body.")
+Keys: :owner :repo :num :head-rev :base-rev :host :comments :memos
+:reviewed.  Each comment and memo is a plist with :path :line :side
+:body; memos stay local and are never submitted.  :reviewed is a list of
+repository-relative file paths the user has flagged as done.")
 
 ;;;; Ediff control & navigation
 
@@ -114,10 +117,13 @@ launches multi-file ediff between PR base and head."
                 :head-rev head-rev
                 :base-rev base-rev
                 :host (my-forge-ediff-review--host-for repo)
-                :comments nil))
+                :comments nil
+                :memos nil
+                :reviewed nil))
     (message
      "Review session for PR #%s started. C-c M c to comment, C-c M C to submit."
      (oref pullreq number))
+    (my-forge-ediff-review--install-sidebar-hooks)
     (my-magit-ediff-all-compare base-rev head-rev)))
 
 (defun my-forge-ediff-review--host-for (repo)
@@ -144,6 +150,12 @@ nil, which makes ghub fall back to `ghub-default-host' (api.github.com)."
   "Face for lines with pending review comments and inline body display."
   :group 'my-forge-ediff-review)
 
+(defface my-forge-ediff-review-memo-face
+  '((((background light)) :background "#ddf4ff" :foreground "#24292f")
+    (((background dark))  :background "#002a3a" :foreground "#ffffff"))
+  "Face for inline memos, which stay local and are never submitted."
+  :group 'my-forge-ediff-review)
+
 (defun my-forge-ediff-review--side-for-rev (rev)
   "Return \"LEFT\" / \"RIGHT\" for REV in the current session, or nil."
   (let ((s my-forge-ediff-review--session))
@@ -151,17 +163,19 @@ nil, which makes ghub fall back to `ghub-default-host' (api.github.com)."
      ((equal rev (plist-get s :base-rev)) "LEFT")
      ((equal rev (plist-get s :head-rev)) "RIGHT"))))
 
-(defun my-forge-ediff-review--format-overlay-body (body)
-  "Indent every line of BODY for inline overlay display."
-  (mapconcat (lambda (l) (concat "    | " l))
+(defun my-forge-ediff-review--format-overlay-body (label body)
+  "Indent every line of BODY for inline overlay display under LABEL."
+  (mapconcat (lambda (l) (concat "    " label " " l))
              (split-string body "\n")
              "\n"))
 
-(defun my-forge-ediff-review--put-overlay (buf line body)
+(defun my-forge-ediff-review--put-overlay (buf line label body face)
   "Append BODY as a highlighted after-string overlay below LINE in BUF.
-The commented source line is left untouched; only the comment text
-itself is highlighted.  The overlay is anchored at end-of-line so it
-does not shift `display-line-numbers-mode' or `nlinum-mode' counts."
+LABEL prefixes each body line (e.g. \"|\" for comments, \"memo\" for
+memos) and FACE highlights the text.  The source line is left untouched;
+only the appended text is highlighted.  The overlay is anchored at
+end-of-line so it does not shift `display-line-numbers-mode' or
+`nlinum-mode' counts."
   (with-current-buffer buf
     (save-excursion
       (goto-char (point-min))
@@ -174,8 +188,9 @@ does not shift `display-line-numbers-mode' or `nlinum-mode' counts."
                      (propertize
                       (concat
                        "\n"
-                       (my-forge-ediff-review--format-overlay-body body))
-                      'face 'my-forge-ediff-review-comment-face))))))
+                       (my-forge-ediff-review--format-overlay-body
+                        label body))
+                      'face face))))))
 
 (defun my-forge-ediff-review--clear-overlays (&optional buf)
   "Remove all review overlays from BUF (defaults to current buffer)."
@@ -183,7 +198,7 @@ does not shift `display-line-numbers-mode' or `nlinum-mode' counts."
     (remove-overlays (point-min) (point-max) 'my-forge-ediff-review t)))
 
 (defun my-forge-ediff-review--reapply-overlays ()
-  "Reapply overlays in current buffer for comments matching its file/side."
+  "Reapply comment and memo overlays in current buffer for its file/side."
   (when (and my-forge-ediff-review--session
              my-magit-ediff--buf-file
              my-magit-ediff--buf-rev)
@@ -192,20 +207,31 @@ does not shift `display-line-numbers-mode' or `nlinum-mode' counts."
            (rev  my-magit-ediff--buf-rev)
            (side (my-forge-ediff-review--side-for-rev rev)))
       (when side
-        (dolist (c (plist-get my-forge-ediff-review--session :comments))
-          (when (and (string= (plist-get c :path) file)
-                     (string= (plist-get c :side) side))
-            (my-forge-ediff-review--put-overlay
-             (current-buffer)
-             (plist-get c :line)
-             (plist-get c :body))))))))
+        (my-forge-ediff-review--put-side-overlays
+         (plist-get my-forge-ediff-review--session :comments)
+         file side "|" 'my-forge-ediff-review-comment-face)
+        (my-forge-ediff-review--put-side-overlays
+         (plist-get my-forge-ediff-review--session :memos)
+         file side "memo" 'my-forge-ediff-review-memo-face)))))
+
+(defun my-forge-ediff-review--put-side-overlays (entries file side label face)
+  "Overlay each of ENTRIES matching FILE and SIDE with LABEL and FACE."
+  (dolist (entry (my-forge-ediff-review-model-entries-for-side
+                  entries file side))
+    (my-forge-ediff-review--put-overlay
+     (current-buffer)
+     (plist-get entry :line)
+     label
+     (plist-get entry :body)
+     face)))
 
 (defun my-forge-ediff-review--refresh-all-buffers ()
-  "Reapply overlays in every live ediff revision buffer of the session."
+  "Reapply overlays in every revision buffer and redraw the sidebar."
   (dolist (buf my-magit-ediff--temp-buffers)
     (when (buffer-live-p buf)
       (with-current-buffer buf
-        (my-forge-ediff-review--reapply-overlays)))))
+        (my-forge-ediff-review--reapply-overlays))))
+  (my-forge-ediff-review--refresh-sidebar))
 
 (defvar-local my-forge-ediff-review--keys-installed nil
   "Non-nil once review navigation keys are installed in this buffer.
@@ -222,6 +248,8 @@ file/rev locals set by `my-magit-ediff--create-revision-buffer'."
              (not my-forge-ediff-review--keys-installed))
     (let ((map (make-composed-keymap nil (current-local-map))))
       (define-key map (kbd "RET") #'my-forge-ediff-review-add-comment)
+      (define-key map (kbd "m") #'my-forge-ediff-review-add-memo)
+      (define-key map (kbd "d") #'my-forge-ediff-review-toggle-reviewed)
       (define-key map (kbd "n") #'my-forge-ediff-review-next-diff)
       (define-key map (kbd "p") #'my-forge-ediff-review-prev-diff)
       (define-key map (kbd "q") #'my-forge-ediff-review-quit-ediff)
@@ -231,7 +259,8 @@ file/rev locals set by `my-magit-ediff--create-revision-buffer'."
 (defun my-forge-ediff-review--prepare-buffer ()
   "Apply overlays and install nav/comment keys in the current revision buffer."
   (my-forge-ediff-review--reapply-overlays)
-  (my-forge-ediff-review--setup-revision-keys))
+  (my-forge-ediff-review--setup-revision-keys)
+  (my-forge-ediff-review--refresh-sidebar))
 
 ;; Hook so that comments persist and review keys exist when ediff
 ;; (re)visits a file.
@@ -256,36 +285,84 @@ when it shows the head."
           (when side
             (list :path file :line line :side side)))))))
 
-;;;; Adding comments
+;;;; Adding comments and memos
+
+;; Comments and memos share one markdown editor.  They differ only in
+;; which session list they land in (:comments is submitted to GitHub,
+;; :memos stays local) and in how repeated entries on a line behave:
+;; a line may carry several comments but only one memo, which is edited
+;; in place and removed when saved empty.
+(defconst my-forge-ediff-review--kinds
+  '((comment . (:key :comments :label "Comment"))
+    (memo    . (:key :memos    :label "Memo")))
+  "Per-kind metadata: session plist key and human label.")
 
 (defvar my-forge-ediff-review--editor-ctx nil
-  "Buffer-local context plist while editing a comment.")
+  "Buffer-local context plist while editing a comment or memo.")
+
+(defvar my-forge-ediff-review--editor-kind nil
+  "Buffer-local kind symbol (`comment' or `memo') of the active editor.")
+
+(defun my-forge-ediff-review--kind-key (kind)
+  "Return the session plist key storing entries of KIND."
+  (plist-get (alist-get kind my-forge-ediff-review--kinds) :key))
+
+(defun my-forge-ediff-review--kind-label (kind)
+  "Return the human-readable label for KIND."
+  (plist-get (alist-get kind my-forge-ediff-review--kinds) :label))
 
 (defun my-forge-ediff-review-add-comment ()
   "Add a PR review comment for the line at point in this ediff buffer."
   (interactive)
+  (my-forge-ediff-review--start-editor 'comment))
+
+(defun my-forge-ediff-review-add-memo ()
+  "Attach a local memo to the line at point.
+Memos are never submitted to GitHub.  Editing the line again reopens the
+existing memo; saving it empty removes it."
+  (interactive)
+  (my-forge-ediff-review--start-editor 'memo))
+
+(defun my-forge-ediff-review--start-editor (kind)
+  "Open the editor of KIND for the current line, validating context first."
   (my-forge-ediff-review--ensure-session)
   (let ((ctx (my-forge-ediff-review--current-context)))
     (unless ctx
       (user-error
        "Not in a review ediff revision buffer (no file/rev context)"))
-    (my-forge-ediff-review--open-editor ctx)))
+    (my-forge-ediff-review--open-editor ctx kind)))
 
-(defun my-forge-ediff-review--open-editor (ctx)
-  "Pop up an editor buffer for a comment described by CTX."
-  (let ((buf (generate-new-buffer "*forge-review-comment*")))
+(defun my-forge-ediff-review--existing-memo-body (ctx)
+  "Return the body of an existing memo at CTX, or nil."
+  (let ((memo (my-forge-ediff-review-model-find-entry
+               (plist-get my-forge-ediff-review--session :memos)
+               (plist-get ctx :path)
+               (plist-get ctx :line)
+               (plist-get ctx :side))))
+    (and memo (plist-get memo :body))))
+
+(defun my-forge-ediff-review--open-editor (ctx kind)
+  "Pop up a markdown editor for an entry of KIND described by CTX."
+  (let ((buf (generate-new-buffer
+              (format "*forge-review-%s*" kind)))
+        (prefill (and (eq kind 'memo)
+                      (my-forge-ediff-review--existing-memo-body ctx))))
     (with-current-buffer buf
       (when (fboundp 'markdown-mode)
         (markdown-mode))
       (insert (format
-               "<!-- %s:%d (%s) — C-c C-c to save, C-c C-k to cancel. \
+               "<!-- %s for %s:%d (%s) — C-c C-c to save, C-c C-k to cancel. \
 HTML comments are stripped. -->\n\n"
+               (my-forge-ediff-review--kind-label kind)
                (plist-get ctx :path)
                (plist-get ctx :line)
                (plist-get ctx :side)))
+      (when prefill
+        (insert prefill))
       (setq-local my-forge-ediff-review--editor-ctx ctx)
-      (local-set-key (kbd "C-c C-c") #'my-forge-ediff-review--save-comment)
-      (local-set-key (kbd "C-c C-k") #'my-forge-ediff-review--cancel-comment)
+      (setq-local my-forge-ediff-review--editor-kind kind)
+      (local-set-key (kbd "C-c C-c") #'my-forge-ediff-review--save-entry)
+      (local-set-key (kbd "C-c C-k") #'my-forge-ediff-review--cancel-entry)
       (goto-char (point-max)))
     (pop-to-buffer buf)))
 
@@ -293,35 +370,53 @@ HTML comments are stripped. -->\n\n"
   "Remove `<!-- ... -->' blocks from TEXT."
   (replace-regexp-in-string "<!--\\(.\\|\n\\)*?-->" "" text))
 
-(defun my-forge-ediff-review--save-comment ()
-  "Finalize the comment in the current editor buffer and store it."
+(defun my-forge-ediff-review--save-entry ()
+  "Finalize the comment/memo in the current editor buffer and store it."
   (interactive)
   (let* ((ctx my-forge-ediff-review--editor-ctx)
-         (raw (buffer-string))
+         (kind my-forge-ediff-review--editor-kind)
          (body (string-trim
-                (my-forge-ediff-review--strip-html-comments raw))))
-    (when (string-empty-p body)
-      (user-error "Comment body is empty"))
+                (my-forge-ediff-review--strip-html-comments
+                 (buffer-string)))))
     (unless my-forge-ediff-review--session
       (user-error "Review session disappeared; not saving"))
-    (let ((comment (append ctx (list :body body))))
-      (setf (plist-get my-forge-ediff-review--session :comments)
-            (cons comment
-                  (plist-get my-forge-ediff-review--session :comments))))
+    (when (and (eq kind 'comment) (string-empty-p body))
+      (user-error "Comment body is empty"))
+    (my-forge-ediff-review--store-entry ctx kind body)
     (let ((buf (current-buffer)))
       (quit-window)
       (kill-buffer buf))
     (my-forge-ediff-review--refresh-all-buffers)
-    (message "Comment saved (%d pending)."
-             (length (plist-get my-forge-ediff-review--session :comments)))))
+    (message "%s saved (%d pending)."
+             (my-forge-ediff-review--kind-label kind)
+             (length (plist-get my-forge-ediff-review--session
+                                 (my-forge-ediff-review--kind-key kind))))))
 
-(defun my-forge-ediff-review--cancel-comment ()
-  "Discard the in-progress comment editor."
+(defun my-forge-ediff-review--store-entry (ctx kind body)
+  "Store an entry of KIND with BODY at CTX into the session.
+A memo replaces any existing memo on the same line and an empty memo
+removes it; comments are always appended."
+  (let* ((key (my-forge-ediff-review--kind-key kind))
+         (entries (plist-get my-forge-ediff-review--session key)))
+    (when (eq kind 'memo)
+      (let ((existing (my-forge-ediff-review-model-find-entry
+                       entries (plist-get ctx :path)
+                       (plist-get ctx :line) (plist-get ctx :side))))
+        (when existing
+          (setq entries (my-forge-ediff-review-model-remove-entry
+                         entries existing)))))
+    (setf (plist-get my-forge-ediff-review--session key)
+          (if (and (eq kind 'memo) (string-empty-p body))
+              entries
+            (cons (append ctx (list :body body)) entries)))))
+
+(defun my-forge-ediff-review--cancel-entry ()
+  "Discard the in-progress comment/memo editor."
   (interactive)
   (let ((buf (current-buffer)))
     (quit-window)
     (kill-buffer buf))
-  (message "Comment cancelled."))
+  (message "Editing cancelled."))
 
 ;;;; Listing / discarding
 
@@ -383,14 +478,7 @@ HTML comments are stripped. -->\n\n"
     `((commit_id . ,(plist-get s :head-rev))
       (event    . ,event)
       (body     . ,(or summary ""))
-      (comments . ,(vconcat
-                    (mapcar
-                     (lambda (c)
-                       `((path . ,(plist-get c :path))
-                         (line . ,(plist-get c :line))
-                         (side . ,(plist-get c :side))
-                         (body . ,(plist-get c :body))))
-                     comments))))))
+      (comments . ,(my-forge-ediff-review-model-payload-comments comments)))))
 
 (defvar my-forge-ediff-review--summary-event nil
   "Buffer-local: the event chosen for the summary editor.")
@@ -476,6 +564,181 @@ C-c C-c submits, C-c C-k cancels. HTML comments are stripped. -->\n\n"
                    (my-forge-ediff-review-list-comments)))
      :errorback (lambda (err &rest _)
                   (message "Review submission failed: %S" err)))))
+
+;;;; Reviewed flag
+
+(defun my-forge-ediff-review--toggle-reviewed-path (path)
+  "Toggle the reviewed flag for PATH and redraw the sidebar."
+  (my-forge-ediff-review--ensure-session)
+  (setf (plist-get my-forge-ediff-review--session :reviewed)
+        (my-forge-ediff-review-model-toggle-reviewed
+         (plist-get my-forge-ediff-review--session :reviewed) path))
+  (my-forge-ediff-review--refresh-sidebar)
+  (message "%s marked %s." path
+           (if (my-forge-ediff-review-model-reviewed-p
+                (plist-get my-forge-ediff-review--session :reviewed) path)
+               "reviewed" "not reviewed")))
+
+(defun my-forge-ediff-review-toggle-reviewed ()
+  "Toggle the reviewed flag for the file in the current revision buffer."
+  (interactive)
+  (my-forge-ediff-review--ensure-session)
+  (let ((path my-magit-ediff--buf-file))
+    (unless path
+      (user-error "Not in a review ediff revision buffer"))
+    (my-forge-ediff-review--toggle-reviewed-path path)))
+
+;;;; File-list sidebar
+
+(defconst my-forge-ediff-review--sidebar-name "*forge-review-files*"
+  "Name of the buffer hosting the GitHub-style file-list sidebar.")
+
+(defvar my-forge-ediff-review-sidebar-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "RET") #'my-forge-ediff-review-sidebar-open)
+    (define-key map (kbd "<mouse-1>") #'my-forge-ediff-review-sidebar-open)
+    (define-key map (kbd "d") #'my-forge-ediff-review-sidebar-toggle-reviewed)
+    (define-key map (kbd "g") #'my-forge-ediff-review-sidebar-refresh)
+    (define-key map (kbd "n") #'next-line)
+    (define-key map (kbd "p") #'previous-line)
+    (define-key map (kbd "q") #'my-forge-ediff-review-sidebar-quit)
+    map)
+  "Keymap for `my-forge-ediff-review-sidebar-mode'.")
+
+(define-derived-mode my-forge-ediff-review-sidebar-mode special-mode
+  "ReviewFiles"
+  "Major mode for the forge ediff review file-list sidebar."
+  (setq truncate-lines t))
+
+(defun my-forge-ediff-review--file-counts (path)
+  "Return a cons (COMMENT-COUNT . MEMO-COUNT) of entries for PATH."
+  (cons (my-forge-ediff-review-model-count-for-file
+         (plist-get my-forge-ediff-review--session :comments) path)
+        (my-forge-ediff-review-model-count-for-file
+         (plist-get my-forge-ediff-review--session :memos) path)))
+
+(defun my-forge-ediff-review--insert-sidebar-file (file current-p reviewed-p)
+  "Insert one sidebar line for FILE carrying its path as a text property.
+CURRENT-P highlights the file open in ediff; REVIEWED-P picks the box."
+  (let* ((counts (my-forge-ediff-review--file-counts file))
+         (text (my-forge-ediff-review-model-format-file-line
+                file current-p reviewed-p (car counts) (cdr counts)))
+         (start (point)))
+    (insert text "\n")
+    (put-text-property start (point) 'my-forge-ediff-review-file file)
+    (when current-p
+      (put-text-property start (point) 'face 'highlight))))
+
+(defun my-forge-ediff-review--render-sidebar ()
+  "Rebuild the sidebar buffer from session and engine state."
+  (let ((buffer (get-buffer-create my-forge-ediff-review--sidebar-name))
+        (reviewed (plist-get my-forge-ediff-review--session :reviewed))
+        (current my-magit-ediff--current-index))
+    (with-current-buffer buffer
+      (unless (derived-mode-p 'my-forge-ediff-review-sidebar-mode)
+        (my-forge-ediff-review-sidebar-mode))
+      (let ((saved-line (line-number-at-pos))
+            (inhibit-read-only t)
+            (index 0))
+        (erase-buffer)
+        (insert (propertize
+                 (format "PR #%s  reviewed %d/%d\n\n"
+                         (plist-get my-forge-ediff-review--session :num)
+                         (length reviewed)
+                         (length my-magit-ediff--files))
+                 'face 'bold))
+        (dolist (file my-magit-ediff--files)
+          (my-forge-ediff-review--insert-sidebar-file
+           file (= index current)
+           (my-forge-ediff-review-model-reviewed-p reviewed file))
+          (setq index (1+ index)))
+        (goto-char (point-min))
+        (forward-line (1- saved-line))))))
+
+(defun my-forge-ediff-review--show-sidebar ()
+  "Display the file-list sidebar in a persistent left side window.
+The `no-delete-other-windows' parameter keeps it alive across ediff's
+own window reconfiguration."
+  (my-forge-ediff-review--render-sidebar)
+  (display-buffer-in-side-window
+   (get-buffer my-forge-ediff-review--sidebar-name)
+   '((side . left)
+     (slot . 0)
+     (window-width . 38)
+     (window-parameters . ((no-delete-other-windows . t))))))
+
+(defun my-forge-ediff-review--refresh-sidebar ()
+  "Redraw the sidebar when it exists."
+  (let ((buffer (get-buffer my-forge-ediff-review--sidebar-name)))
+    (when (buffer-live-p buffer)
+      (my-forge-ediff-review--render-sidebar))))
+
+(defun my-forge-ediff-review--sidebar-file-at-point ()
+  "Return the file on the current sidebar line or signal an error."
+  (or (get-text-property (point) 'my-forge-ediff-review-file)
+      (user-error "No file on this line")))
+
+(defun my-forge-ediff-review-sidebar-open ()
+  "Open ediff for the file on the current sidebar line."
+  (interactive)
+  (let* ((file (my-forge-ediff-review--sidebar-file-at-point))
+         (index (seq-position my-magit-ediff--files file #'string=)))
+    (when index
+      (my-magit-ediff-goto-index index))))
+
+(defun my-forge-ediff-review-sidebar-toggle-reviewed ()
+  "Toggle the reviewed flag for the file on the current sidebar line."
+  (interactive)
+  (my-forge-ediff-review--toggle-reviewed-path
+   (my-forge-ediff-review--sidebar-file-at-point)))
+
+(defun my-forge-ediff-review-sidebar-refresh ()
+  "Redraw the sidebar on demand."
+  (interactive)
+  (my-forge-ediff-review--render-sidebar))
+
+(defun my-forge-ediff-review-sidebar-quit ()
+  "End the review session.  Quit the open diff first if one is shown."
+  (interactive)
+  (let ((control my-magit-ediff--control-buffer))
+    (if (and control (buffer-live-p control))
+        (message "Quit the current diff first (press q in it), then q here.")
+      (my-magit-ediff--cleanup)
+      (message "Review ended."))))
+
+;;;; Lifecycle wiring between the engine and the sidebar
+
+(defun my-forge-ediff-review--navigation ()
+  "Keep the sidebar in control after a file is quit, instead of prompting."
+  (my-forge-ediff-review--render-sidebar)
+  (let ((window (get-buffer-window my-forge-ediff-review--sidebar-name)))
+    (when (window-live-p window)
+      (select-window window))))
+
+(defun my-forge-ediff-review--on-cleanup ()
+  "Tear down the sidebar and review session when the engine cleans up."
+  (let ((buffer (get-buffer my-forge-ediff-review--sidebar-name)))
+    (when (buffer-live-p buffer)
+      (let ((window (get-buffer-window buffer)))
+        (when (window-live-p window)
+          (ignore-errors (delete-window window))))
+      (kill-buffer buffer)))
+  (setq my-magit-ediff-navigation-function
+        #'my-magit-ediff--prompt-navigation)
+  (remove-hook 'my-magit-ediff-start-hook
+               #'my-forge-ediff-review--show-sidebar)
+  (remove-hook 'my-magit-ediff-cleanup-hook
+               #'my-forge-ediff-review--on-cleanup)
+  (setq my-forge-ediff-review--session nil))
+
+(defun my-forge-ediff-review--install-sidebar-hooks ()
+  "Route engine navigation and cleanup through the review sidebar."
+  (setq my-magit-ediff-navigation-function
+        #'my-forge-ediff-review--navigation)
+  (add-hook 'my-magit-ediff-start-hook
+            #'my-forge-ediff-review--show-sidebar)
+  (add-hook 'my-magit-ediff-cleanup-hook
+            #'my-forge-ediff-review--on-cleanup))
 
 (provide 'my-forge-ediff-review)
 ;;; my-forge-ediff-review.el ends here

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -88,6 +88,15 @@ repository-relative file paths the user has flagged as done.")
 
 ;;;; Session lifecycle
 
+(defun my-forge-ediff-review--diff-base (base-rev head-rev)
+  "Return the commit to diff HEAD-REV against when reviewing a PR.
+GitHub shows a PR as the three-dot diff `base...head', i.e. against the
+merge-base where the branch diverged, not against the base branch tip.
+Diffing against the tip (a two-dot diff) would fold in commits that landed
+on the base branch after the PR forked, inflating the file list with
+unrelated changes.  Fall back to BASE-REV when no merge-base is found."
+  (or (magit-git-string "merge-base" base-rev head-rev) base-rev))
+
 (defun my-forge-ediff-review-start (pullreq)
   "Start an ediff-based review session for forge PULLREQ.
 Verifies that the PR commits are fetched, records the session, and
@@ -110,21 +119,24 @@ launches multi-file ediff between PR base and head."
                              (length (plist-get my-forge-ediff-review--session
                                                 :comments))))))
       (user-error "Aborted"))
-    (setq my-forge-ediff-review--session
-          (list :owner (oref repo owner)
-                :repo (oref repo name)
-                :num (oref pullreq number)
-                :head-rev head-rev
-                :base-rev base-rev
-                :host (my-forge-ediff-review--host-for repo)
-                :comments nil
-                :memos nil
-                :reviewed nil))
-    (message
-     "Review session for PR #%s started. C-c M c to comment, C-c M C to submit."
-     (oref pullreq number))
-    (my-forge-ediff-review--install-sidebar-hooks)
-    (my-magit-ediff-all-compare base-rev head-rev)))
+    ;; `:base-rev' must track the diff base so that
+    ;; `my-forge-ediff-review--side-for-rev' still maps the base pane to LEFT.
+    (let ((diff-base (my-forge-ediff-review--diff-base base-rev head-rev)))
+      (setq my-forge-ediff-review--session
+            (list :owner (oref repo owner)
+                  :repo (oref repo name)
+                  :num (oref pullreq number)
+                  :head-rev head-rev
+                  :base-rev diff-base
+                  :host (my-forge-ediff-review--host-for repo)
+                  :comments nil
+                  :memos nil
+                  :reviewed nil))
+      (message
+       "Review session for PR #%s started. C-c M c to comment, C-c M C to submit."
+       (oref pullreq number))
+      (my-forge-ediff-review--install-sidebar-hooks)
+      (my-magit-ediff-all-compare diff-base head-rev))))
 
 (defun my-forge-ediff-review--host-for (repo)
   "Return the API host to use for REPO, or nil for ghub's default.

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -299,11 +299,11 @@ when it shows the head."
 
 ;;;; Adding comments and memos
 
-;; Comments and memos share one markdown editor.  They differ only in
-;; which session list they land in (:comments is submitted to GitHub,
-;; :memos stays local) and in how repeated entries on a line behave:
-;; a line may carry several comments but only one memo, which is edited
-;; in place and removed when saved empty.
+;; Comments and memos share one markdown editor and behave the same way:
+;; a line carries at most one entry of each kind, reopening the editor
+;; prefills the existing body for in-place editing, and saving it empty
+;; removes it.  They differ only in which session list they land in
+;; (:comments is submitted to GitHub, :memos stays local).
 (defconst my-forge-ediff-review--kinds
   '((comment . (:key :comments :label "Comment"))
     (memo    . (:key :memos    :label "Memo")))
@@ -324,7 +324,9 @@ when it shows the head."
   (plist-get (alist-get kind my-forge-ediff-review--kinds) :label))
 
 (defun my-forge-ediff-review-add-comment ()
-  "Add a PR review comment for the line at point in this ediff buffer."
+  "Add a PR review comment for the line at point in this ediff buffer.
+Reopening the editor on the same line prefills the existing comment for
+in-place editing; saving it empty removes it."
   (interactive)
   (my-forge-ediff-review--start-editor 'comment))
 
@@ -344,21 +346,21 @@ existing memo; saving it empty removes it."
        "Not in a review ediff revision buffer (no file/rev context)"))
     (my-forge-ediff-review--open-editor ctx kind)))
 
-(defun my-forge-ediff-review--existing-memo-body (ctx)
-  "Return the body of an existing memo at CTX, or nil."
-  (let ((memo (my-forge-ediff-review-model-find-entry
-               (plist-get my-forge-ediff-review--session :memos)
-               (plist-get ctx :path)
-               (plist-get ctx :line)
-               (plist-get ctx :side))))
-    (and memo (plist-get memo :body))))
+(defun my-forge-ediff-review--existing-entry-body (ctx kind)
+  "Return the body of an existing entry of KIND at CTX, or nil."
+  (let ((entry (my-forge-ediff-review-model-find-entry
+                (plist-get my-forge-ediff-review--session
+                           (my-forge-ediff-review--kind-key kind))
+                (plist-get ctx :path)
+                (plist-get ctx :line)
+                (plist-get ctx :side))))
+    (and entry (plist-get entry :body))))
 
 (defun my-forge-ediff-review--open-editor (ctx kind)
   "Pop up a markdown editor for an entry of KIND described by CTX."
   (let ((buf (generate-new-buffer
               (format "*forge-review-%s*" kind)))
-        (prefill (and (eq kind 'memo)
-                      (my-forge-ediff-review--existing-memo-body ctx))))
+        (prefill (my-forge-ediff-review--existing-entry-body ctx kind)))
     (with-current-buffer buf
       (when (fboundp 'markdown-mode)
         (markdown-mode))
@@ -392,8 +394,6 @@ HTML comments are stripped. -->\n\n"
                  (buffer-string)))))
     (unless my-forge-ediff-review--session
       (user-error "Review session disappeared; not saving"))
-    (when (and (eq kind 'comment) (string-empty-p body))
-      (user-error "Comment body is empty"))
     (my-forge-ediff-review--store-entry ctx kind body)
     (let ((buf (current-buffer)))
       (quit-window)
@@ -406,19 +406,18 @@ HTML comments are stripped. -->\n\n"
 
 (defun my-forge-ediff-review--store-entry (ctx kind body)
   "Store an entry of KIND with BODY at CTX into the session.
-A memo replaces any existing memo on the same line and an empty memo
-removes it; comments are always appended."
+An entry replaces any existing entry of the same KIND on the same line
+and side; an empty BODY removes it."
   (let* ((key (my-forge-ediff-review--kind-key kind))
-         (entries (plist-get my-forge-ediff-review--session key)))
-    (when (eq kind 'memo)
-      (let ((existing (my-forge-ediff-review-model-find-entry
-                       entries (plist-get ctx :path)
-                       (plist-get ctx :line) (plist-get ctx :side))))
-        (when existing
-          (setq entries (my-forge-ediff-review-model-remove-entry
-                         entries existing)))))
+         (entries (plist-get my-forge-ediff-review--session key))
+         (existing (my-forge-ediff-review-model-find-entry
+                    entries (plist-get ctx :path)
+                    (plist-get ctx :line) (plist-get ctx :side))))
+    (when existing
+      (setq entries (my-forge-ediff-review-model-remove-entry
+                     entries existing)))
     (setf (plist-get my-forge-ediff-review--session key)
-          (if (and (eq kind 'memo) (string-empty-p body))
+          (if (string-empty-p body)
               entries
             (cons (append ctx (list :body body)) entries)))))
 

--- a/lisp/my-magit-ediff.el
+++ b/lisp/my-magit-ediff.el
@@ -50,6 +50,31 @@
 (defvar my-magit-ediff--saved-window-config nil
   "Window configuration captured at session start, restored on cleanup.")
 
+(defvar my-magit-ediff--control-buffer nil
+  "The ediff control buffer of the file currently under comparison.
+Captured from `ediff-buffers' so callers such as the review sidebar can
+quit the active comparison without being inside one of its buffers.")
+
+(defvar my-magit-ediff--pending-index nil
+  "File index to open after the current comparison quits, or nil.
+Set by `my-magit-ediff-goto-index' so a jump requested while a file is
+open is performed once `ediff-quit-hook' has torn that file down.")
+
+;; Extension points for layers built on top of this engine (e.g. the
+;; forge review sidebar).  Kept as plain variables/hooks rather than
+;; subclasses so the engine stays unaware of any particular consumer.
+(defvar my-magit-ediff-navigation-function
+  #'my-magit-ediff--prompt-navigation
+  "Function called after a file is quit to choose the next action.
+Defaults to the built-in `completing-read' prompt.  A consumer may bind
+it to keep its own UI (such as a persistent sidebar) in control.")
+
+(defvar my-magit-ediff-start-hook nil
+  "Hook run once the first file of a session has been opened.")
+
+(defvar my-magit-ediff-cleanup-hook nil
+  "Hook run by `my-magit-ediff--cleanup' before session state is reset.")
+
 ;;;; Entry point functions
 
 ;;;###autoload
@@ -95,7 +120,8 @@
         my-magit-ediff--saved-window-config (current-window-configuration))
   (my-magit-ediff--hide-side-windows)
   (add-hook 'ediff-quit-hook #'my-magit-ediff--on-quit)
-  (my-magit-ediff--open-current))
+  (my-magit-ediff--open-current)
+  (run-hooks 'my-magit-ediff-start-hook))
 
 (defun my-magit-ediff--open-current ()
   "Open ediff for the file at current index."
@@ -120,13 +146,27 @@
   (when (window-with-parameter 'window-side nil nil)
     (window-toggle-side-windows)))
 
+(defun my-magit-ediff--select-content-window ()
+  "Select a normal window so ediff never tries to set up in a side window.
+A side window (such as the review sidebar) cannot be split or made the
+sole window, which would make ediff's plain window setup error out."
+  (when (window-parameter (selected-window) 'window-side)
+    (let ((normal (seq-find
+                   (lambda (window)
+                     (not (window-parameter window 'window-side)))
+                   (window-list))))
+      (when normal
+        (select-window normal)))))
+
 (defun my-magit-ediff--open-file (file)
-  "Open ediff for a single FILE using current rev-a/rev-b."
+  "Open ediff for a single FILE using current rev-a/rev-b.
+Stores the resulting control buffer in `my-magit-ediff--control-buffer'."
+  (my-magit-ediff--select-content-window)
   (let ((buf-a (my-magit-ediff--create-revision-buffer
                 file my-magit-ediff--rev-a))
         (buf-b (my-magit-ediff--create-revision-buffer
                 file my-magit-ediff--rev-b)))
-    (ediff-buffers buf-a buf-b)))
+    (setq my-magit-ediff--control-buffer (ediff-buffers buf-a buf-b))))
 
 (defun my-magit-ediff--create-revision-buffer (file rev)
   "Create a buffer with FILE content at REV.
@@ -182,16 +222,37 @@ If REV is a string, return that revision's content."
     (run-at-time 0.1 nil #'my-magit-ediff--after-quit)))
 
 (defun my-magit-ediff--after-quit ()
-  "Kill temp buffers from previous session, then show navigation.
-If the navigation prompt is aborted (e.g. `C-g'), run cleanup so the
-session state and `ediff-quit-hook' do not leak into later, unrelated
-ediff sessions."
+  "Kill temp buffers, then jump to a pending file or run navigation.
+When `my-magit-ediff--pending-index' is set (a jump requested from the
+sidebar), open that file.  Otherwise delegate to
+`my-magit-ediff-navigation-function'.  If that navigation is aborted
+\(e.g. `C-g'), run cleanup so the session state and `ediff-quit-hook' do
+not leak into later, unrelated ediff sessions."
   (my-magit-ediff--kill-temp-buffers)
-  (condition-case nil
-      (my-magit-ediff--prompt-navigation)
-    (quit
-     (my-magit-ediff--cleanup)
-     (message "Review ended."))))
+  (if my-magit-ediff--pending-index
+      (let ((index my-magit-ediff--pending-index))
+        (setq my-magit-ediff--pending-index nil
+              my-magit-ediff--current-index index)
+        (my-magit-ediff--open-current))
+    (condition-case nil
+        (funcall my-magit-ediff-navigation-function)
+      (quit
+       (my-magit-ediff--cleanup)
+       (message "Review ended.")))))
+
+(defun my-magit-ediff-goto-index (index)
+  "Switch the active multi-file session to the file at INDEX.
+If a comparison is open, quit it first; the jump then happens in
+`my-magit-ediff--after-quit'.  Otherwise open the file directly."
+  (unless my-magit-ediff--active
+    (user-error "No active multi-file ediff session"))
+  (let ((control my-magit-ediff--control-buffer))
+    (if (and control (buffer-live-p control))
+        (progn
+          (setq my-magit-ediff--pending-index index)
+          (with-current-buffer control (ediff-really-quit nil)))
+      (setq my-magit-ediff--current-index index)
+      (my-magit-ediff--open-current))))
 
 (defun my-magit-ediff--build-file-labels ()
   "Build labeled file list for `completing-read'."
@@ -236,14 +297,19 @@ candidate to the top, which scrambles the visual order."
           (my-magit-ediff--open-current))))))
 
 (defun my-magit-ediff--cleanup ()
-  "Reset state variables, restore windows, and remove hook."
+  "Reset state variables, restore windows, and remove hook.
+`my-magit-ediff-cleanup-hook' runs first so consumers can tear down
+their own UI (such as the review sidebar) while session state is intact."
+  (run-hooks 'my-magit-ediff-cleanup-hook)
   (my-magit-ediff--kill-temp-buffers)
   (setq my-magit-ediff--files nil
         my-magit-ediff--current-index 0
         my-magit-ediff--rev-a nil
         my-magit-ediff--rev-b nil
         my-magit-ediff--total-count 0
-        my-magit-ediff--active nil)
+        my-magit-ediff--active nil
+        my-magit-ediff--control-buffer nil
+        my-magit-ediff--pending-index nil)
   (remove-hook 'ediff-quit-hook #'my-magit-ediff--on-quit)
   (when my-magit-ediff--saved-window-config
     (set-window-configuration my-magit-ediff--saved-window-config)

--- a/lisp/my-magit-ediff.el
+++ b/lisp/my-magit-ediff.el
@@ -158,15 +158,55 @@ sole window, which would make ediff's plain window setup error out."
       (when normal
         (select-window normal)))))
 
+(defun my-magit-ediff--capture-side-windows ()
+  "Return a spec describing the frame's side windows for later restoration.
+Each entry is (BUFFER SIDE SLOT WIDTH) so `my-magit-ediff--restore-side-windows'
+can recreate the window in the same slot."
+  (let ((spec nil))
+    (dolist (window (window-list nil 'no-mini))
+      (when (window-parameter window 'window-side)
+        (push (list (window-buffer window)
+                    (window-parameter window 'window-side)
+                    (window-parameter window 'window-slot)
+                    (window-total-width window))
+              spec)))
+    spec))
+
+(defun my-magit-ediff--restore-side-windows (spec)
+  "Recreate the side windows captured in SPEC.
+SPEC comes from `my-magit-ediff--capture-side-windows'."
+  (dolist (entry spec)
+    (when (buffer-live-p (nth 0 entry))
+      (display-buffer-in-side-window
+       (nth 0 entry)
+       `((side . ,(nth 1 entry))
+         (slot . ,(nth 2 entry))
+         (window-width . ,(nth 3 entry))
+         (window-parameters . ((no-delete-other-windows . t))))))))
+
 (defun my-magit-ediff--open-file (file)
   "Open ediff for a single FILE using current rev-a/rev-b.
-Stores the resulting control buffer in `my-magit-ediff--control-buffer'."
-  (my-magit-ediff--select-content-window)
-  (let ((buf-a (my-magit-ediff--create-revision-buffer
-                file my-magit-ediff--rev-a))
-        (buf-b (my-magit-ediff--create-revision-buffer
-                file my-magit-ediff--rev-b)))
-    (setq my-magit-ediff--control-buffer (ediff-buffers buf-a buf-b))))
+Stores the resulting control buffer in `my-magit-ediff--control-buffer'.
+
+Side windows (the review sidebar) are removed for the duration of ediff's
+window setup and recreated afterward.  Ediff's plain setup clears the frame
+with `delete-other-windows' before laying out its panes, but that is a no-op
+while a side window is present, so the previous file's windows survive and
+pile up with every navigation.  Tearing the side windows down lets ediff
+start from a single clean window."
+  (my-magit-ediff--kill-stale-revision-buffers)
+  (let ((side-spec (my-magit-ediff--capture-side-windows)))
+    (dolist (window (window-list nil 'no-mini))
+      (when (window-parameter window 'window-side)
+        (ignore-errors (delete-window window))))
+    (my-magit-ediff--select-content-window)
+    (delete-other-windows)
+    (let ((buf-a (my-magit-ediff--create-revision-buffer
+                  file my-magit-ediff--rev-a))
+          (buf-b (my-magit-ediff--create-revision-buffer
+                  file my-magit-ediff--rev-b)))
+      (setq my-magit-ediff--control-buffer (ediff-buffers buf-a buf-b)))
+    (my-magit-ediff--restore-side-windows side-spec)))
 
 (defun my-magit-ediff--create-revision-buffer (file rev)
   "Create a buffer with FILE content at REV.
@@ -215,6 +255,19 @@ If REV is a string, return that revision's content."
       (kill-buffer buf)))
   (setq my-magit-ediff--temp-buffers nil))
 
+(defun my-magit-ediff--kill-stale-revision-buffers ()
+  "Kill leftover revision buffers generated for earlier files.
+Only buffers built from a git revision (a non-nil `my-magit-ediff--buf-rev',
+i.e. a commit SHA or `index') are killed, so the working-tree file buffer
+\(nil rev) is never touched and unsaved edits are preserved.  This guards
+against revision buffers piling up when navigation skips the normal quit
+path, such as rapid file switches from the review sidebar."
+  (dolist (buffer (buffer-list))
+    (when (and (buffer-live-p buffer)
+               (buffer-local-value 'my-magit-ediff--buf-rev buffer))
+      (kill-buffer buffer)))
+  (setq my-magit-ediff--temp-buffers nil))
+
 (defun my-magit-ediff--on-quit ()
   "Hook called when ediff session ends. Show navigation prompt if active."
   (when my-magit-ediff--active
@@ -248,6 +301,11 @@ If a comparison is open, quit it first; the jump then happens in
     (user-error "No active multi-file ediff session"))
   (let ((control my-magit-ediff--control-buffer))
     (if (and control (buffer-live-p control))
+        ;; A comparison is open, so we cannot stack the next ediff on top
+        ;; of it.  Record the target and quit; quitting runs `ediff-quit-hook'
+        ;; -> `my-magit-ediff--on-quit' -> `my-magit-ediff--after-quit', which
+        ;; opens `my-magit-ediff--pending-index'.  The next ediff is therefore
+        ;; launched through the quit hook, not synchronously here.
         (progn
           (setq my-magit-ediff--pending-index index)
           (with-current-buffer control (ediff-really-quit nil)))

--- a/tests/my-forge-ediff-review-model-test.el
+++ b/tests/my-forge-ediff-review-model-test.el
@@ -5,7 +5,7 @@
 ;; `my-forge-ediff-review-model'.  These helpers have no dependency on
 ;; magit/forge/ghub, so they can be exercised in batch with:
 ;;
-;;   emacs -batch -L lisp -l lisp/my-forge-ediff-review-model-test.el \
+;;   emacs -batch -L lisp -l tests/my-forge-ediff-review-model-test.el \
 ;;     -f ert-run-tests-batch-and-exit
 
 ;;; Code:

--- a/tests/my-forge-ediff-review-test.el
+++ b/tests/my-forge-ediff-review-test.el
@@ -1,0 +1,99 @@
+;;; my-forge-ediff-review-test.el --- Editor/store regression tests -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Tests for the comment/memo editor backing logic in
+;; `my-forge-ediff-review' (`--store-entry' and `--existing-entry-body').
+;; Comments and memos behave the same way: a line carries at most one
+;; entry of each kind, reopening prefills the existing body for in-place
+;; editing, and saving empty removes it.
+;;
+;; Loading `my-forge-ediff-review' pulls in ghub/magit, so the tests are
+;; skipped when that stack is unavailable.  Run with:
+;;
+;;   emacs -Q --batch --eval "(package-initialize)" \
+;;     -L lisp -l ert -l tests/my-forge-ediff-review-test.el \
+;;     -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+
+(defvar my-forge-ediff-review-test--available
+  (and (require 'magit nil t)
+       (require 'ediff nil t)
+       (progn
+         (add-to-list 'load-path
+                      (expand-file-name
+                       "../lisp"
+                       (file-name-directory (or load-file-name buffer-file-name))))
+         (require 'my-forge-ediff-review nil t))
+       t)
+  "Non-nil when the magit/ghub stack needed by these tests is loadable.")
+
+(defconst my-forge-ediff-review-test--ctx '(:path "a.el" :line 10 :side "RIGHT")
+  "A sample line context shared by the tests.")
+
+(defmacro my-forge-ediff-review-test--with-session (initial &rest body)
+  "Run BODY with `my-forge-ediff-review--session' bound to INITIAL."
+  (declare (indent 1))
+  `(let ((my-forge-ediff-review--session ,initial))
+     ,@body))
+
+(ert-deftest my-forge-ediff-review-replaces-existing-comment-on-same-line ()
+  "Re-saving a comment on the same line replaces it instead of appending."
+  (skip-unless my-forge-ediff-review-test--available)
+  (my-forge-ediff-review-test--with-session (list :comments nil :memos nil)
+    (my-forge-ediff-review--store-entry
+     my-forge-ediff-review-test--ctx 'comment "first")
+    (my-forge-ediff-review--store-entry
+     my-forge-ediff-review-test--ctx 'comment "second")
+    (let ((comments (plist-get my-forge-ediff-review--session :comments)))
+      (should (= 1 (length comments)))
+      (should (equal "second" (plist-get (car comments) :body))))))
+
+(ert-deftest my-forge-ediff-review-keeps-comments-on-different-lines ()
+  "Comments on distinct lines coexist."
+  (skip-unless my-forge-ediff-review-test--available)
+  (my-forge-ediff-review-test--with-session (list :comments nil :memos nil)
+    (my-forge-ediff-review--store-entry
+     '(:path "a.el" :line 10 :side "RIGHT") 'comment "ten")
+    (my-forge-ediff-review--store-entry
+     '(:path "a.el" :line 20 :side "RIGHT") 'comment "twenty")
+    (should (= 2 (length (plist-get my-forge-ediff-review--session :comments))))))
+
+(ert-deftest my-forge-ediff-review-removes-comment-saved-empty ()
+  "Saving an empty body removes the existing comment on that line."
+  (skip-unless my-forge-ediff-review-test--available)
+  (my-forge-ediff-review-test--with-session
+      (list :comments (list (append my-forge-ediff-review-test--ctx
+                                    (list :body "old")))
+            :memos nil)
+    (my-forge-ediff-review--store-entry
+     my-forge-ediff-review-test--ctx 'comment "")
+    (should (null (plist-get my-forge-ediff-review--session :comments)))))
+
+(ert-deftest my-forge-ediff-review-prefills-existing-comment-body ()
+  "Reopening the editor on a commented line returns its body for prefill."
+  (skip-unless my-forge-ediff-review-test--available)
+  (my-forge-ediff-review-test--with-session
+      (list :comments (list (append my-forge-ediff-review-test--ctx
+                                    (list :body "draft")))
+            :memos nil)
+    (should (equal "draft"
+                   (my-forge-ediff-review--existing-entry-body
+                    my-forge-ediff-review-test--ctx 'comment)))))
+
+(ert-deftest my-forge-ediff-review-still-replaces-existing-memo ()
+  "Memo behaviour is unchanged: one editable memo per line."
+  (skip-unless my-forge-ediff-review-test--available)
+  (my-forge-ediff-review-test--with-session (list :comments nil :memos nil)
+    (my-forge-ediff-review--store-entry
+     my-forge-ediff-review-test--ctx 'memo "m1")
+    (my-forge-ediff-review--store-entry
+     my-forge-ediff-review-test--ctx 'memo "m2")
+    (let ((memos (plist-get my-forge-ediff-review--session :memos)))
+      (should (= 1 (length memos)))
+      (should (equal "m2" (plist-get (car memos) :body))))))
+
+(provide 'my-forge-ediff-review-test)
+;;; my-forge-ediff-review-test.el ends here

--- a/tests/my-magit-ediff-window-test.el
+++ b/tests/my-magit-ediff-window-test.el
@@ -15,6 +15,11 @@
 ;;    dropped on the normal quit path, so switching files outside it left
 ;;    stale `file (rev)' buffers behind.
 ;;
+;; 3. Wrong diff base.  The review diffed against the base branch tip, so a
+;;    base branch that advanced after the PR forked folded its unrelated
+;;    commits into the file list.  The review must diff against the
+;;    merge-base, matching GitHub's `base...head' view.
+;;
 ;; The tests reproduce a review session over a throwaway git repository,
 ;; navigate between files through the engine (the same path the sidebar's
 ;; RET uses), and assert that neither windows nor revision buffers grow.
@@ -168,6 +173,64 @@ Return the repository directory."
      (dolist (index '(1 2 0 1))
        (my-magit-ediff-window-test--goto-via-sidebar index)
        (should (= 2 (my-magit-ediff-window-test--revision-buffer-count)))))))
+
+(defun my-magit-ediff-window-test--make-divergent-repo ()
+  "Create a repo whose base branch advanced after a feature branch forked.
+The feature branch changes `a.txt'; the base branch (master) then gains an
+unrelated `z.txt'.  Return a plist with :dir :base-tip :head and :merge-base."
+  (let ((dir (make-temp-file "my-magit-ediff-divergent" t)))
+    (my-magit-ediff-window-test--run-git dir "init" "-q" "-b" "master")
+    (my-magit-ediff-window-test--run-git dir "config" "user.email" "t@example.com")
+    (my-magit-ediff-window-test--run-git dir "config" "user.name" "Test")
+    (my-magit-ediff-window-test--write-lines (expand-file-name "a.txt" dir) "a1" "a2")
+    (my-magit-ediff-window-test--run-git dir "add" "a.txt")
+    (my-magit-ediff-window-test--run-git dir "commit" "-qm" "base")
+    (let ((default-directory (file-name-as-directory dir)))
+      (let ((fork-point (magit-git-string "rev-parse" "HEAD")))
+        (my-magit-ediff-window-test--run-git dir "checkout" "-q" "-b" "feature")
+        (my-magit-ediff-window-test--write-lines
+         (expand-file-name "a.txt" dir) "a1" "CHANGED")
+        (my-magit-ediff-window-test--run-git dir "add" "a.txt")
+        (my-magit-ediff-window-test--run-git dir "commit" "-qm" "feature change")
+        (let ((head (magit-git-string "rev-parse" "HEAD")))
+          (my-magit-ediff-window-test--run-git dir "checkout" "-q" "master")
+          (my-magit-ediff-window-test--write-lines
+           (expand-file-name "z.txt" dir) "z1")
+          (my-magit-ediff-window-test--run-git dir "add" "z.txt")
+          (my-magit-ediff-window-test--run-git dir "commit" "-qm" "unrelated base change")
+          (list :dir dir
+                :base-tip (magit-git-string "rev-parse" "HEAD")
+                :head head
+                :merge-base fork-point))))))
+
+(ert-deftest my-forge-ediff-review-diffs-against-merge-base ()
+  "The review diff base must be the merge-base, not the advanced base tip."
+  (skip-unless my-magit-ediff-window-test--available)
+  (let ((repo (my-magit-ediff-window-test--make-divergent-repo)))
+    (unwind-protect
+        (let ((default-directory (file-name-as-directory (plist-get repo :dir))))
+          (should (equal (plist-get repo :merge-base)
+                         (my-forge-ediff-review--diff-base
+                          (plist-get repo :base-tip) (plist-get repo :head))))
+          (should-not (equal (plist-get repo :base-tip) (plist-get repo :merge-base))))
+      (delete-directory (plist-get repo :dir) t))))
+
+(ert-deftest my-forge-ediff-review-excludes-unrelated-base-commits ()
+  "Diffing from the merge-base must list only the PR's own changes."
+  (skip-unless my-magit-ediff-window-test--available)
+  (let ((repo (my-magit-ediff-window-test--make-divergent-repo)))
+    (unwind-protect
+        (let* ((default-directory (file-name-as-directory (plist-get repo :dir)))
+               (diff-base (my-forge-ediff-review--diff-base
+                           (plist-get repo :base-tip) (plist-get repo :head))))
+          ;; From the merge-base only the PR's file shows up.
+          (should (equal '("a.txt")
+                         (magit-changed-files diff-base (plist-get repo :head))))
+          ;; Diffing from the advanced base tip wrongly folds in z.txt.
+          (should (member "z.txt"
+                          (magit-changed-files (plist-get repo :base-tip)
+                                               (plist-get repo :head)))))
+      (delete-directory (plist-get repo :dir) t))))
 
 (provide 'my-magit-ediff-window-test)
 ;;; my-magit-ediff-window-test.el ends here

--- a/tests/my-magit-ediff-window-test.el
+++ b/tests/my-magit-ediff-window-test.el
@@ -1,0 +1,173 @@
+;;; my-magit-ediff-window-test.el --- Window/buffer regression tests -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Regression tests for the multi-file ediff review session, covering two
+;; bugs that made a long review session pile up state on screen:
+;;
+;; 1. Window accumulation.  While a side window (the forge review sidebar)
+;;    is shown, ediff's plain window setup clears the frame with
+;;    `delete-other-windows', which is a no-op as long as a side window is
+;;    present.  The previous file's windows therefore survived every
+;;    navigation, fell back to an unrelated buffer once their revision
+;;    buffers were killed, and stacked up.
+;;
+;; 2. Buffer accumulation.  Each file's two revision buffers were only
+;;    dropped on the normal quit path, so switching files outside it left
+;;    stale `file (rev)' buffers behind.
+;;
+;; The tests reproduce a review session over a throwaway git repository,
+;; navigate between files through the engine (the same path the sidebar's
+;; RET uses), and assert that neither windows nor revision buffers grow.
+;; They need magit/ediff on the load path, so they are skipped when those
+;; are unavailable (e.g. a minimal batch run).  Run with:
+;;
+;;   emacs -Q --batch --eval "(package-initialize)" \
+;;     -L lisp -l ert -l tests/my-magit-ediff-window-test.el \
+;;     -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+
+(defvar my-magit-ediff-window-test--available
+  (and (require 'magit nil t)
+       (require 'ediff nil t)
+       (progn
+         (add-to-list 'load-path
+                      (expand-file-name
+                       "../lisp"
+                       (file-name-directory (or load-file-name buffer-file-name))))
+         (require 'my-magit-ediff nil t))
+       (require 'my-forge-ediff-review nil t))
+  "Non-nil when the magit/ediff stack needed by these tests is loadable.")
+
+(defun my-magit-ediff-window-test--run-git (dir &rest args)
+  "Run git with ARGS inside DIR, signalling on failure."
+  (let ((default-directory (file-name-as-directory dir)))
+    (unless (zerop (apply #'call-process "git" nil nil nil args))
+      (error "git %S failed in %s" args dir))))
+
+(defun my-magit-ediff-window-test--write-lines (path &rest lines)
+  "Write LINES to PATH, one per line."
+  (with-temp-file path
+    (dolist (line lines) (insert line "\n"))))
+
+(defun my-magit-ediff-window-test--make-repo ()
+  "Create a temporary git repo with three files changed across two commits.
+Return the repository directory."
+  (let ((dir (make-temp-file "my-magit-ediff-test" t)))
+    (my-magit-ediff-window-test--run-git dir "init" "-q")
+    (my-magit-ediff-window-test--run-git dir "config" "user.email" "t@example.com")
+    (my-magit-ediff-window-test--run-git dir "config" "user.name" "Test")
+    (dolist (name '("a" "b" "c"))
+      (my-magit-ediff-window-test--write-lines
+       (expand-file-name (concat name ".txt") dir)
+       (concat name "1") (concat name "2") (concat name "3")))
+    (my-magit-ediff-window-test--run-git dir "add" "a.txt" "b.txt" "c.txt")
+    (my-magit-ediff-window-test--run-git dir "commit" "-qm" "base")
+    (dolist (name '("a" "b" "c"))
+      (my-magit-ediff-window-test--write-lines
+       (expand-file-name (concat name ".txt") dir)
+       (concat name "1") "CHANGED" (concat name "3")))
+    (my-magit-ediff-window-test--run-git dir "add" "a.txt" "b.txt" "c.txt")
+    (my-magit-ediff-window-test--run-git dir "commit" "-qm" "head")
+    dir))
+
+(defun my-magit-ediff-window-test--orphan-window-p (window)
+  "Return non-nil when WINDOW is neither a revision pane, control panel, nor sidebar."
+  (let ((buffer (window-buffer window)))
+    (not (or (buffer-local-value 'my-magit-ediff--buf-file buffer)
+             (string-match-p "Ediff Control Panel" (buffer-name buffer))
+             (window-parameter window 'window-side)))))
+
+(defun my-magit-ediff-window-test--orphan-count ()
+  "Count orphan windows in the selected frame."
+  (length (seq-filter #'my-magit-ediff-window-test--orphan-window-p
+                      (window-list nil 'no-mini))))
+
+(defun my-magit-ediff-window-test--normal-window-count ()
+  "Count non-side windows in the selected frame."
+  (length (seq-remove (lambda (window) (window-parameter window 'window-side))
+                      (window-list nil 'no-mini))))
+
+(defun my-magit-ediff-window-test--sidebar-shown-p ()
+  "Return non-nil when the review sidebar window is visible."
+  (and (seq-find (lambda (window)
+                   (string-match-p "forge-review-files"
+                                   (buffer-name (window-buffer window))))
+                 (window-list nil 'no-mini))
+       t))
+
+(defun my-magit-ediff-window-test--revision-buffer-count ()
+  "Count live revision buffers generated for the session."
+  (length (seq-filter (lambda (buffer)
+                        (buffer-local-value 'my-magit-ediff--buf-file buffer))
+                      (buffer-list))))
+
+(defun my-magit-ediff-window-test--force-after-quit ()
+  "Run the deferred `my-magit-ediff--after-quit' timer synchronously."
+  (dolist (timer (copy-sequence timer-list))
+    (when (eq (timer--function timer) 'my-magit-ediff--after-quit)
+      (cancel-timer timer)
+      (apply (timer--function timer) (timer--args timer)))))
+
+(defun my-magit-ediff-window-test--goto-via-sidebar (index)
+  "Select the sidebar and switch the active session to file INDEX."
+  (let ((sidebar (seq-find
+                  (lambda (window)
+                    (string-match-p "forge-review-files"
+                                    (buffer-name (window-buffer window))))
+                  (window-list nil 'no-mini))))
+    (when sidebar (select-window sidebar)))
+  (my-magit-ediff-goto-index index)
+  (my-magit-ediff-window-test--force-after-quit))
+
+(defun my-magit-ediff-window-test--call-with-session (body)
+  "Set up a review session over a throwaway repo, run BODY, then tear it down."
+  (let ((repo (my-magit-ediff-window-test--make-repo))
+        (ediff-window-setup-function #'ediff-setup-windows-plain)
+        (ediff-split-window-function #'split-window-horizontally)
+        (ediff-keep-variants t))
+    (unwind-protect
+        (let ((default-directory (file-name-as-directory repo)))
+          (setq my-forge-ediff-review--session
+                (list :num 1 :base-rev "HEAD~1" :head-rev "HEAD"
+                      :comments nil :memos nil :reviewed nil))
+          (my-forge-ediff-review--install-sidebar-hooks)
+          (my-magit-ediff-all-compare "HEAD~1" "HEAD")
+          (funcall body))
+      (ignore-errors (my-magit-ediff--cleanup))
+      (delete-directory repo t))))
+
+(ert-deftest my-magit-ediff-leaves-no-orphan-window-on-navigation ()
+  "Navigating files with the review sidebar shown must not leave orphan windows."
+  (skip-unless my-magit-ediff-window-test--available)
+  (my-magit-ediff-window-test--call-with-session
+   (lambda ()
+     (should (= 0 (my-magit-ediff-window-test--orphan-count)))
+     (my-magit-ediff-window-test--goto-via-sidebar 1)
+     (should (= 0 (my-magit-ediff-window-test--orphan-count)))
+     (my-magit-ediff-window-test--goto-via-sidebar 0)
+     (should (= 0 (my-magit-ediff-window-test--orphan-count))))))
+
+(ert-deftest my-magit-ediff-keeps-window-count-stable-across-navigation ()
+  "Repeated navigation must keep exactly the control panel and two panes."
+  (skip-unless my-magit-ediff-window-test--available)
+  (my-magit-ediff-window-test--call-with-session
+   (lambda ()
+     (dolist (index '(2 1 0 2 1))
+       (my-magit-ediff-window-test--goto-via-sidebar index)
+       (should (= 3 (my-magit-ediff-window-test--normal-window-count)))
+       (should (my-magit-ediff-window-test--sidebar-shown-p))))))
+
+(ert-deftest my-magit-ediff-keeps-revision-buffers-bounded ()
+  "Revision buffers from earlier files must not accumulate across navigation."
+  (skip-unless my-magit-ediff-window-test--available)
+  (my-magit-ediff-window-test--call-with-session
+   (lambda ()
+     (dolist (index '(1 2 0 1))
+       (my-magit-ediff-window-test--goto-via-sidebar index)
+       (should (= 2 (my-magit-ediff-window-test--revision-buffer-count)))))))
+
+(provide 'my-magit-ediff-window-test)
+;;; my-magit-ediff-window-test.el ends here


### PR DESCRIPTION
## Reviewing a forge PR had no overview and no place for local notes

The forge ediff review could only capture inline comments destined for
GitHub. Walking a multi-file PR still relied on the completing-read
navigation prompt, so there was no overview of progress and nowhere to
jot notes that should stay local rather than become PR comments.

## A GitHub-style sidebar, reviewed flags, and local memos

- A persistent sidebar (`my-forge-ediff-review-sidebar-mode`) lists the
  PR's files with a reviewed marker and per-file comment/memo counts, and
  opens a file's ediff on `RET`.
- A per-file reviewed flag, toggled from the sidebar or `C-c M f`.
- Local memos (`C-c M m`) shown inline as overlays but never submitted to
  GitHub, edited through the same editor as comments via a "kind" switch.

## Engine extension points instead of a hard dependency

So the forge layer can own navigation without the generic engine knowing
about it, `my-magit-ediff` gains a `navigation-function`, start/cleanup
hooks, `goto-index`, and control-buffer tracking (so a file can be quit
from outside its own ediff buffers).

## Pure model, unit-tested in batch

The side-effect-free logic (reviewed-path set, entry lookup, line
formatting, payload shaping) lives in `my-forge-ediff-review-model.el`
and is covered by 16 ERT tests that run without the magit/forge/ghub
stack.

## Verified

- `emacs --batch` ERT run for the model: 16/16 pass.
- Changed files byte-compile cleanly; `my-forge-ediff-review.el` emits
  only batch-only "Unknown slot" notes for valid forge eieio slots
  (`base-rev`/`head-rev`/`owner`) because forge's classes are not loaded
  in batch.
- No Japanese and no trailing whitespace in the changed files.

Generated with [Claude Code](https://claude.com/claude-code)