### PR TITLE
Reply to existing PR review threads from ediff

### DIFF
--- a/lisp/my-forge-ediff-review-model.el
+++ b/lisp/my-forge-ediff-review-model.el
@@ -118,8 +118,10 @@ alist `((data . PAYLOAD))'.  Both resolve to PAYLOAD here."
 
 (defun my-forge-ediff-review-model-parse-review-threads (response)
   "Parse a GitHub reviewThreads GraphQL RESPONSE into overlay entries.
-Each entry is a plist (:path :line :side :body :author :resolved) where
-:side is \"LEFT\"/\"RIGHT\" and :resolved reflects the thread.  GitHub
+Each entry is a plist (:path :line :side :body :author :resolved
+:thread-id :reply-to-id) where :side is \"LEFT\"/\"RIGHT\" and :resolved
+reflects the thread.  :thread-id and :reply-to-id identify the thread and
+its first comment so replies can be posted to it.  GitHub
 exposes `path', `line', `originalLine' and `diffSide' on the thread, not
 on `PullRequestReviewComment', so the location is read from the thread
 and only the body/author come from each comment.  A thread with no
@@ -131,20 +133,23 @@ entries keep their thread/comment order."
                    pullreq 'reviewThreads))
          (entries nil))
     (dolist (thread threads (nreverse entries))
-      (let ((resolved (my-forge-ediff-review-model--truthy-p
-                       (alist-get 'isResolved thread)))
-            (path (alist-get 'path thread))
-            (line (or (alist-get 'line thread)
-                      (alist-get 'originalLine thread)))
-            (side (alist-get 'diffSide thread))
-            (comments (my-forge-ediff-review-model--graphql-nodes
-                       thread 'comments)))
+      (let* ((resolved (my-forge-ediff-review-model--truthy-p
+                        (alist-get 'isResolved thread)))
+             (thread-id (alist-get 'id thread))
+             (path (alist-get 'path thread))
+             (line (or (alist-get 'line thread)
+                       (alist-get 'originalLine thread)))
+             (side (alist-get 'diffSide thread))
+             (comments (my-forge-ediff-review-model--graphql-nodes
+                        thread 'comments))
+             (reply-to-id (alist-get 'databaseId (car comments))))
         (when (and path line side)
           (dolist (comment comments)
             (let ((body (alist-get 'body comment))
                   (author (alist-get 'login (alist-get 'author comment))))
               (push (list :path path :line line :side side :body body
-                          :author author :resolved resolved)
+                          :author author :resolved resolved
+                          :thread-id thread-id :reply-to-id reply-to-id)
                     entries))))))))
 
 ;;;; API host resolution

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -167,9 +167,10 @@ forges resolve to nil so ghub falls back to its default host."
        pullRequest(number:$number){
          reviewThreads(first:100){
            nodes{
+             id
              isResolved path line originalLine diffSide
              comments(first:100){
-               nodes{ body author{login} }
+               nodes{ databaseId body author{login} }
              }
            }
          }
@@ -334,6 +335,7 @@ file/rev locals set by `my-magit-ediff--create-revision-buffer'."
     (let ((map (make-composed-keymap nil (current-local-map))))
       (define-key map (kbd "RET") #'my-forge-ediff-review-add-comment)
       (define-key map (kbd "m") #'my-forge-ediff-review-add-memo)
+      (define-key map (kbd "r") #'my-forge-ediff-review-reply-to-comment)
       (define-key map (kbd "d") #'my-forge-ediff-review-toggle-reviewed)
       (define-key map (kbd "n") #'my-forge-ediff-review-next-diff)
       (define-key map (kbd "p") #'my-forge-ediff-review-prev-diff)
@@ -501,6 +503,81 @@ and side; an empty BODY removes it."
     (quit-window)
     (kill-buffer buf))
   (message "Editing cancelled."))
+
+;;;; Replying to existing review threads
+
+(defvar my-forge-ediff-review--reply-target nil
+  "Buffer-local entry plist of the existing comment being replied to.")
+
+(defun my-forge-ediff-review--existing-at-point ()
+  "Return the first existing review comment entry on the line at point, or nil."
+  (let ((ctx (my-forge-ediff-review--current-context)))
+    (and ctx
+         (my-forge-ediff-review-model-find-entry
+          (plist-get my-forge-ediff-review--session :existing)
+          (plist-get ctx :path)
+          (plist-get ctx :line)
+          (plist-get ctx :side)))))
+
+(defun my-forge-ediff-review-reply-to-comment ()
+  "Reply to the existing review thread on the line at point.
+The reply is posted immediately to GitHub; it is not part of the batch
+of pending comments collected for a new review."
+  (interactive)
+  (my-forge-ediff-review--ensure-session)
+  (let ((entry (my-forge-ediff-review--existing-at-point)))
+    (unless entry
+      (user-error "No existing review comment on this line to reply to"))
+    (unless (plist-get entry :reply-to-id)
+      (user-error "This review comment cannot be replied to (no comment id)"))
+    (my-forge-ediff-review--open-reply-editor entry)))
+
+(defun my-forge-ediff-review--open-reply-editor (entry)
+  "Pop up a markdown editor to reply to the thread described by ENTRY."
+  (let ((buf (generate-new-buffer "*forge-review-reply*")))
+    (with-current-buffer buf
+      (when (fboundp 'markdown-mode)
+        (markdown-mode))
+      (insert (format
+               "<!-- Reply to %s at %s:%d (%s) — C-c C-c to send, \
+C-c C-k to cancel.  HTML comments are stripped. -->\n\n"
+               (or (plist-get entry :author) "reviewer")
+               (plist-get entry :path)
+               (plist-get entry :line)
+               (plist-get entry :side)))
+      (setq-local my-forge-ediff-review--reply-target entry)
+      (local-set-key (kbd "C-c C-c") #'my-forge-ediff-review--send-reply)
+      (local-set-key (kbd "C-c C-k") #'my-forge-ediff-review--cancel-entry)
+      (goto-char (point-max)))
+    (pop-to-buffer buf)))
+
+(defun my-forge-ediff-review--send-reply ()
+  "POST the reply in the current editor buffer, then refresh existing threads."
+  (interactive)
+  (my-forge-ediff-review--ensure-session)
+  (let* ((entry my-forge-ediff-review--reply-target)
+         (reply-to-id (plist-get entry :reply-to-id))
+         (body (string-trim
+                (my-forge-ediff-review--strip-html-comments
+                 (buffer-string))))
+         (s my-forge-ediff-review--session))
+    (when (string-empty-p body)
+      (user-error "Reply body is empty"))
+    (ghub-post
+     (format "/repos/%s/%s/pulls/%s/comments/%s/replies"
+             (plist-get s :owner) (plist-get s :repo)
+             (plist-get s :num) reply-to-id)
+     `((body . ,body))
+     :auth 'forge
+     :host (plist-get s :host)
+     :callback (lambda (_value &rest _)
+                 (message "Reply sent.")
+                 (my-forge-ediff-review--fetch-existing-threads))
+     :errorback (lambda (err &rest _)
+                  (message "Reply failed: %S" err)))
+    (let ((buf (current-buffer)))
+      (quit-window)
+      (kill-buffer buf))))
 
 ;;;; Listing / discarding
 

--- a/tests/my-forge-ediff-review-model-test.el
+++ b/tests/my-forge-ediff-review-model-test.el
@@ -235,6 +235,29 @@ LOCATION is an alist providing the thread-level `path', `line',
     (should (= 3 (plist-get entry :line)))
     (should (equal "RIGHT" (plist-get entry :side)))))
 
+(ert-deftest review-model-should-carry-thread-and-reply-target ()
+  ;; The thread id and the first comment's databaseId let later replies
+  ;; target the right thread; both comments in a thread share the reply
+  ;; target.  Location lives on the thread, so the comment nodes only carry
+  ;; databaseId, body and author.
+  (let* ((thread
+          `((id . "THREAD_kw1")
+            (isResolved . :json-false)
+            (path . "a.el") (line . 3) (diffSide . "RIGHT")
+            (comments
+             (nodes . ,(vector
+                        '((databaseId . 555) (body . "first")
+                          (author (login . "u")))
+                        '((databaseId . 556) (body . "second")
+                          (author (login . "v"))))))))
+         (response (my-forge-ediff-review-model-test--threads-response
+                    (vector thread)))
+         (entries (my-forge-ediff-review-model-parse-review-threads response)))
+    (should (= 2 (length entries)))
+    (should (equal "THREAD_kw1" (plist-get (car entries) :thread-id)))
+    (should (= 555 (plist-get (car entries) :reply-to-id)))
+    (should (= 555 (plist-get (cadr entries) :reply-to-id)))))
+
 ;;;; API host resolution (github.com and GitHub Enterprise)
 
 (ert-deftest review-model-resolve-host-should-return-github-apihost ()


### PR DESCRIPTION
> Stacked on #294 → #293. GitHub will retarget the base as each parent merges.

Roadmap step 2 toward GitHub-web-console parity: reply to review threads.

## No way to respond to existing review discussion

#294 shows existing review comments inline, but there was no way to
respond to them from the ediff session.

## Reply on `r`, posted immediately

Pressing `r` on a line that carries an existing review comment opens a
markdown editor; `C-c C-c` posts the reply to that thread via the GitHub
replies REST endpoint (`POST .../pulls/{n}/comments/{id}/replies`) and
re-fetches the threads so the reply appears inline. `C-c C-k` cancels.

Replies are intentionally separate from the batch of pending comments
collected for a new review — a reply is a single immediate action on an
existing thread, as in the web console.

## Parser carries the reply target

The `reviewThreads` query now also requests each thread's node `id` and
each comment's `databaseId`. The pure parser attaches `:thread-id` and a
`:reply-to-id` (the thread's first comment id) to every entry, covered by
an added ERT test. Model suite: 22/22; byte-compile clean.

## Verification note

Pure parser + byte-compile verified here; the live reply POST could not be
exercised (no interactive GitHub auth). Please confirm on a real PR: open
with `C-c M e`, put point on a line with an existing comment, press `r`,
write a reply, `C-c C-c`, and check it lands on the thread.

Generated with [Claude Code](https://claude.com/claude-code)