### PR TITLE
Add agent-shell mode for ACP coding agents

### DIFF
--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -1495,6 +1495,23 @@ The source buffer is added as gptel context for full file awareness."
   :config
   (claude-code-ide-emacs-tools-setup))
 
+;; agent-shell: chat with ACP-compatible coding agents (Claude, Gemini)
+;; in a comint-based shell buffer. Talks to agents over the Agent Client
+;; Protocol via acp.el, so each agent needs its own CLI on PATH. Install
+;; the agent executables before use:
+;;   npm install -g @agentclientprotocol/claude-agent-acp  ; for Claude
+;;   npm install -g @google/gemini-cli                     ; for Gemini
+(use-package agent-shell
+  :ensure t
+  :bind (("C-c q" . agent-shell-anthropic-start-claude-code)
+         ("C-c C-q" . agent-shell-google-start-gemini))
+  :custom
+  ;; Reuse the local Claude/Gemini CLI logins instead of storing API keys.
+  (agent-shell-anthropic-authentication
+   (agent-shell-anthropic-make-authentication :login t))
+  (agent-shell-google-authentication
+   (agent-shell-google-make-authentication :login t)))
+
 (use-package string-inflection :ensure t
   :config (global-set-key (kbd "C-c i") 'string-inflection-cycle))
 


### PR DESCRIPTION
## Chat with ACP coding agents from within Emacs

Adds an `agent-shell` use-package block so Claude and Gemini coding agents
can be driven from a comint-based shell buffer over the Agent Client
Protocol (via acp.el). This complements the existing `claude-code-ide`
(Claude CLI in vterm) and `gptel` (Gemini chat) setups by offering an
ACP-native conversational shell.

## No API keys stored in the config

Authentication reuses the local Claude/Gemini CLI logins through
`:login t`, so nothing sensitive lives in the dotfiles.

## Keybindings and required CLIs

- `C-c q` starts a Claude session, `C-c C-q` starts a Gemini session
  (the latter only shadows org-mode's local binding outside org buffers).
- The header comment documents the `npm install -g` commands needed to put
  each agent executable on PATH before use.

## Verification

- `lisp/init-prog.el` byte-compiles with no agent-shell-specific errors
  (only pre-existing warnings remain).
- The ERT suite passes (26/26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)