### PR TITLE
Support GitHub Enterprise hosts in ediff PR review

### DIFF
--- a/lisp/my-forge-ediff-review-model.el
+++ b/lisp/my-forge-ediff-review-model.el
@@ -94,5 +94,17 @@ Memos are never passed here, so they cannot leak into a submission."
         (body . ,(plist-get comment :body))))
     comments)))
 
+;;;; API host resolution
+
+(defun my-forge-ediff-review-model-resolve-host (apihost)
+  "Return the ghub `:host' value for a forge repository's APIHOST.
+APIHOST is the repository's `apihost' slot: \"api.github.com\" for
+github.com or, for a GitHub Enterprise instance, that instance's API
+host such as \"ghe.example.com/api/v3\".  A nil or empty APIHOST yields
+nil, which lets ghub fall back to its own default host."
+  (and (stringp apihost)
+       (not (string-empty-p apihost))
+       apihost))
+
 (provide 'my-forge-ediff-review-model)
 ;;; my-forge-ediff-review-model.el ends here

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -128,7 +128,7 @@ launches multi-file ediff between PR base and head."
                   :num (oref pullreq number)
                   :head-rev head-rev
                   :base-rev diff-base
-                  :host (my-forge-ediff-review--host-for repo)
+                  :host (my-forge-ediff-review--resolve-host repo)
                   :comments nil
                   :memos nil
                   :reviewed nil))
@@ -138,16 +138,15 @@ launches multi-file ediff between PR base and head."
       (my-forge-ediff-review--install-sidebar-hooks)
       (my-magit-ediff-all-compare diff-base head-rev))))
 
-(defun my-forge-ediff-review--host-for (repo)
+(defun my-forge-ediff-review--resolve-host (repo)
   "Return the API host to use for REPO, or nil for ghub's default.
-Only github.com is supported for now: a GitHub repository resolves to
-nil, which makes ghub fall back to `ghub-default-host' (api.github.com)."
-  ;; TODO: support GitHub Enterprise by returning the repository's own API
-  ;; host (e.g. forge's `apihost' slot) instead of always nil.
+Supports both github.com and GitHub Enterprise: the host comes from the
+repository's own `apihost' slot, which ghub uses verbatim to build the
+REST and GraphQL endpoints (api.github.com for github.com).  Non-GitHub
+forges resolve to nil so ghub falls back to its default host."
   (when (and (fboundp 'forge-github-repository-p)
              (forge-github-repository-p repo))
-    ;; nil makes ghub default to `ghub-default-host' which is api.github.com.
-    nil))
+    (my-forge-ediff-review-model-resolve-host (oref repo apihost))))
 
 (defun my-forge-ediff-review--ensure-session ()
   "Signal an error if no review session is active."

--- a/tests/my-forge-ediff-review-model-test.el
+++ b/tests/my-forge-ediff-review-model-test.el
@@ -128,5 +128,22 @@
       (should (equal "RIGHT" (alist-get 'side c)))
       (should (equal "body" (alist-get 'body c))))))
 
+;;;; API host resolution (github.com and GitHub Enterprise)
+
+(ert-deftest review-model-resolve-host-should-return-github-apihost ()
+  (should (equal "api.github.com"
+                 (my-forge-ediff-review-model-resolve-host "api.github.com"))))
+
+(ert-deftest review-model-resolve-host-should-return-enterprise-apihost ()
+  (should (equal "ghe.example.com/api/v3"
+                 (my-forge-ediff-review-model-resolve-host
+                  "ghe.example.com/api/v3"))))
+
+(ert-deftest review-model-resolve-host-should-return-nil-when-nil ()
+  (should-not (my-forge-ediff-review-model-resolve-host nil)))
+
+(ert-deftest review-model-resolve-host-should-return-nil-when-empty ()
+  (should-not (my-forge-ediff-review-model-resolve-host "")))
+
 (provide 'my-forge-ediff-review-model-test)
 ;;; my-forge-ediff-review-model-test.el ends here


### PR DESCRIPTION
## Summary

The ediff-based PR review feature previously hardcoded the API host to
`nil` (`my-forge-ediff-review--host-for` always returned nil), so review
submission only worked against github.com. This resolves the host from
the forge repository's `apihost` slot instead, enabling reviews against
GitHub Enterprise instances.

ghub builds both its REST and GraphQL endpoints from `:host` verbatim
(`forge--host-arguments` does the same `(oref repo apihost)`). For
github.com the `apihost` is `api.github.com`, which is ghub's default, so
behavior there is unchanged.

## Changes

- Add pure model fn `my-forge-ediff-review-model-resolve-host` that
  normalizes a repository's `apihost` (empty/nil -> nil so ghub falls
  back to its default), with ERT coverage.
- Rename `--host-for` -> `--resolve-host` (verb-first naming rule) and
  have it return `(oref repo apihost)` via the model fn for GitHub /
  GitHub Enterprise repositories.
- Remove the obsolete `TODO: support GitHub Enterprise` marker.

## Testing

- `byte-compile`: clean for both changed lisp files.
- ERT: full suite passes (30/30), including 4 new `resolve-host` tests.
- Live verification on a real GitHub Enterprise PR is pending (requires
  interactive GitHub auth) — to be done by the maintainer before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)