### PR TITLE
Focus-resize the review sidebar like a magit side window

### DIFF
--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -364,32 +364,40 @@ CONDITION is a regexp string matching buffer names.")
            (window-parameters . ((no-delete-other-windows . t))))))
     (magit-status)))
 
-;;; Magit left side window: expand on focus, shrink on blur
+;;; Left side windows: expand on focus, shrink on blur
 ;;
-;; A magit buffer shown in a left side window is too narrow for everyday
-;; reading, but a permanently wide side window steals horizontal space from
-;; the main editing area. The block below resolves this by watching
-;; `window-selection-change-functions' and resizing any left-side magit
-;; window to `my-magit-side-window-focused-width' while it has focus, and
-;; back to `my-magit-side-window-unfocused-width' as soon as focus moves
-;; away.
+;; A magit buffer (or the forge ediff review file-list sidebar) shown in a
+;; left side window is too narrow for everyday reading, but a permanently
+;; wide side window steals horizontal space from the main editing area. The
+;; block below resolves this by watching `window-selection-change-functions'
+;; and resizing such a window to `my-magit-side-window-focused-width' while
+;; it has focus, and back to `my-magit-side-window-unfocused-width' as soon
+;; as focus moves away.  Resizing the review sidebar on every focus also
+;; re-asserts its width after ediff transiently shrinks it on navigation.
 
 (defcustom my-magit-side-window-focused-width 80
-  "Width in columns for a magit left side window while it has focus."
+  "Width in columns for a focus-resize left side window while it has focus.
+Applies to magit buffers and the review file-list sidebar."
   :type 'integer
   :group 'magit)
 
 (defcustom my-magit-side-window-unfocused-width 30
-  "Width in columns for a magit left side window while it does not have focus."
+  "Width in columns for a focus-resize left side window without focus.
+Applies to magit buffers and the review file-list sidebar."
   :type 'integer
   :group 'magit)
 
 (defun my-magit-left-side-window-p (window)
-  "Return non-nil when WINDOW is a left side window showing a magit buffer."
+  "Return non-nil when WINDOW is a left side window that should focus-resize.
+Covers magit buffers and the forge ediff review file-list sidebar
+\(`*forge-review-files*'), so both widen while selected and shrink back on
+blur.  The sidebar is matched by buffer name to avoid loading the review
+feature just to know its mode."
   (and (window-live-p window)
        (eq (window-parameter window 'window-side) 'left)
-       (with-current-buffer (window-buffer window)
-         (derived-mode-p 'magit-mode))))
+       (let ((buffer (window-buffer window)))
+         (or (with-current-buffer buffer (derived-mode-p 'magit-mode))
+             (equal (buffer-name buffer) "*forge-review-files*")))))
 
 (defun my-magit-resize-window-to (window target-width)
   "Resize WINDOW horizontally to TARGET-WIDTH columns."
@@ -401,10 +409,10 @@ CONDITION is a regexp string matching buffer names.")
         (window-resize window width-delta t t)))))
 
 (defun my-magit-adjust-side-window-on-focus (&optional frame)
-  "Widen the focused magit left side window in FRAME and narrow the others.
-Hooked into `window-selection-change-functions' so a magit side window is
-expanded only while it is selected, and shrunk back as soon as focus moves
-away."
+  "Widen the focused focus-resize left side window in FRAME, narrow the others.
+Hooked into `window-selection-change-functions' so such a side window (a
+magit buffer or the review file-list sidebar) is expanded only while it is
+selected, and shrunk back as soon as focus moves away."
   (let ((selected-window-in-frame (frame-selected-window frame)))
     (dolist (frame-window (window-list frame))
       (when (my-magit-left-side-window-p frame-window)


### PR DESCRIPTION
## Problem

Switching the file under review by pressing RET in the file-list sidebar
(`*forge-review-files*`) left the sidebar stuck narrow (and the diff panes
uneven): ediff's quit transiently resizes the surviving side window, and
the previous fix attempts locked in that resized width.

## Approach (per review feedback)

Rather than tracking width in the ediff engine, extend the existing magit
left-side-window focus-resize machinery in init-ui.el to also cover the
review sidebar:

- `my-magit-left-side-window-p` now matches the `*forge-review-files*`
  buffer (by name) in addition to magit buffers.
- The sidebar therefore widens to `my-magit-side-window-focused-width`
  while selected and shrinks to `my-magit-side-window-unfocused-width` on
  blur — the same UX as the magit status side window.

As a side effect this fixes the original bug: even though ediff transiently
shrinks the sidebar on navigation, the focus change during navigation
re-asserts the intended width. No per-window width bookkeeping is needed in
the ediff engine, so this PR touches only init-ui.el.

## Notes

- Scope is just `lisp/init-ui.el` (the earlier display-buffer-alist and
  engine changes on this branch were reverted).
- The focus-resize behavior lives in init-ui.el and is driven by
  `window-selection-change-functions` (redisplay), so it is verified
  interactively rather than by ERT, consistent with the pre-existing magit
  focus-resize. The predicate/resize logic was validated with a standalone
  probe. The existing engine ERT suite still passes (36/36); byte-compile
  is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)