### PR TITLE
Add boxed card formatting for inline review comments

### DIFF
--- a/lisp/my-forge-ediff-review-model.el
+++ b/lisp/my-forge-ediff-review-model.el
@@ -121,13 +121,18 @@ on its own line rather than split."
 
 (defun my-forge-ediff-review-model--card-summary (glyph header body)
   "Return a one-line summary string for a collapsed card.
-Combines GLYPH, HEADER and the first non-empty line of BODY."
-  (let ((first (seq-find (lambda (l) (not (string-empty-p l)))
-                         (split-string (or body "") "\n"))))
+Combines GLYPH, HEADER and the first non-empty line of BODY.  When BODY
+carries more than that one line, a trailing ellipsis marks the hidden
+content so the fold reads as intentional rather than a lost body."
+  (let* ((lines (seq-remove #'string-empty-p
+                            (split-string (or body "") "\n")))
+         (first (car lines))
+         (more (> (length lines) 1)))
     (concat glyph " " header
             (if (and first (not (string-empty-p first)))
                 (concat ": " first)
-              ""))))
+              "")
+            (if more " …" ""))))
 
 (defun my-forge-ediff-review-model-format-card
     (glyph header body width &optional collapsed)
@@ -139,7 +144,9 @@ the string has no leading or trailing newline.  When COLLAPSED is
 non-nil a single compact summary line is returned instead of the full
 box, so line-number safety is unchanged either way."
   (if collapsed
-      (concat "▎ "
+      ;; A right-pointing triangle reads as "expandable/folded" so a
+      ;; one-line summary is not mistaken for a broken multi-line body.
+      (concat "▸ "
               (my-forge-ediff-review-model--pad
                (truncate-string-to-width
                 (my-forge-ediff-review-model--card-summary glyph header body)

--- a/lisp/my-forge-ediff-review-model.el
+++ b/lisp/my-forge-ediff-review-model.el
@@ -16,6 +16,8 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'seq)
+(require 'iso8601)
 
 ;;;; Reviewed flag
 
@@ -80,6 +82,103 @@ appended only when non-zero."
             (my-forge-ediff-review-model--counts-suffix
              comment-count memo-count))))
 
+;;;; Inline comment card formatting
+
+;; Comment bodies are rendered as a box-drawn "card" placed below the
+;; source line.  Every visual line is padded to the same display width so
+;; a single background face paints a clean rectangle rather than ragged
+;; text (the trick borrowed from annotate.el).  These helpers are pure
+;; strings-in/strings-out so they can be unit-tested without ediff.
+
+(defun my-forge-ediff-review-model--pad (str width)
+  "Right-pad STR with spaces to WIDTH display columns.
+Width is measured with `string-width', so a wide glyph counts as two
+columns.  STR is returned unchanged when already at least WIDTH wide."
+  (let ((w (string-width str)))
+    (if (>= w width)
+        str
+      (concat str (make-string (- width w) ?\s)))))
+
+(defun my-forge-ediff-review-model--wrap-text (text width)
+  "Word-wrap TEXT to WIDTH columns, returning a list of lines.
+Newlines already in TEXT are kept as hard breaks so blank lines between
+markdown paragraphs survive.  A single word wider than WIDTH is emitted
+on its own line rather than split."
+  (let (out)
+    (dolist (para (split-string (or text "") "\n"))
+      (if (string-empty-p para)
+          (push "" out)
+        (let ((cur "") (col 0))
+          (dolist (word (split-string para "[ \t]+" t))
+            (let ((wl (string-width word)))
+              (cond
+               ((string-empty-p cur) (setq cur word col wl))
+               ((<= (+ col 1 wl) width)
+                (setq cur (concat cur " " word) col (+ col 1 wl)))
+               (t (push cur out) (setq cur word col wl)))))
+          (push cur out))))
+    (nreverse out)))
+
+(defun my-forge-ediff-review-model--card-summary (glyph header body)
+  "Return a one-line summary string for a collapsed card.
+Combines GLYPH, HEADER and the first non-empty line of BODY."
+  (let ((first (seq-find (lambda (l) (not (string-empty-p l)))
+                         (split-string (or body "") "\n"))))
+    (concat glyph " " header
+            (if (and first (not (string-empty-p first)))
+                (concat ": " first)
+              ""))))
+
+(defun my-forge-ediff-review-model-format-card
+    (glyph header body width &optional collapsed)
+  "Return a box-drawn annotation card string for HEADER and BODY.
+GLYPH is a short per-kind marker shown in the header and WIDTH is the
+inner content width in columns.  Every returned line is padded to the
+same display width so a single background face paints a clean rectangle;
+the string has no leading or trailing newline.  When COLLAPSED is
+non-nil a single compact summary line is returned instead of the full
+box, so line-number safety is unchanged either way."
+  (if collapsed
+      (concat "▎ "
+              (my-forge-ediff-review-model--pad
+               (truncate-string-to-width
+                (my-forge-ediff-review-model--card-summary glyph header body)
+                (1+ width) nil nil "…")
+               (1+ width))
+              " ")
+    (let* ((header-line (concat glyph " " header))
+           (text (if (string-empty-p (string-trim (or body "")))
+                     " "
+                   body))
+           (lines (or (my-forge-ediff-review-model--wrap-text text width)
+                      '("")))
+           ;; Grow the box to the widest line so the header (author +
+           ;; timestamp) is never clipped and every row stays rectangular.
+           (inner (apply #'max width
+                         (mapcar #'string-width (cons header-line lines))))
+           (rule (make-string (+ inner 2) ?─)))
+      (mapconcat
+       #'identity
+       (append
+        (list (concat "╭" rule "╮")
+              (concat "│ " (my-forge-ediff-review-model--pad header-line inner)
+                      " │")
+              (concat "├" rule "┤"))
+        (mapcar (lambda (l)
+                  (concat "│ " (my-forge-ediff-review-model--pad l inner)
+                          " │"))
+                lines)
+        (list (concat "╰" rule "╯")))
+       "\n"))))
+
+(defun my-forge-ediff-review-model-format-time (iso)
+  "Return a short local-time string for GitHub ISO8601 timestamp ISO.
+ISO looks like \"2026-01-15T10:30:00Z\".  A nil or empty ISO yields the
+empty string so callers can omit the time without extra whitespace."
+  (if (and (stringp iso) (not (string-empty-p iso)))
+      (format-time-string "%Y-%m-%d %H:%M" (encode-time (iso8601-parse iso)))
+    ""))
+
 ;;;; GitHub review payload
 
 (defun my-forge-ediff-review-model-payload-comments (comments)
@@ -118,9 +217,10 @@ alist `((data . PAYLOAD))'.  Both resolve to PAYLOAD here."
 
 (defun my-forge-ediff-review-model-parse-review-threads (response)
   "Parse a GitHub reviewThreads GraphQL RESPONSE into overlay entries.
-Each entry is a plist (:path :line :side :body :author :resolved
-:thread-id :reply-to-id) where :side is \"LEFT\"/\"RIGHT\" and :resolved
-reflects the thread.  :thread-id and :reply-to-id identify the thread and
+Each entry is a plist (:path :line :side :body :author :created-at
+:resolved :thread-id :reply-to-id) where :side is \"LEFT\"/\"RIGHT\" and
+:resolved reflects the thread.  :created-at is the comment's ISO8601
+timestamp.  :thread-id and :reply-to-id identify the thread and
 its first comment so replies can be posted to it.  GitHub
 exposes `path', `line', `originalLine' and `diffSide' on the thread, not
 on `PullRequestReviewComment', so the location is read from the thread
@@ -146,9 +246,11 @@ entries keep their thread/comment order."
         (when (and path line side)
           (dolist (comment comments)
             (let ((body (alist-get 'body comment))
-                  (author (alist-get 'login (alist-get 'author comment))))
+                  (author (alist-get 'login (alist-get 'author comment)))
+                  (created-at (alist-get 'createdAt comment)))
               (push (list :path path :line line :side side :body body
-                          :author author :resolved resolved
+                          :author author :created-at created-at
+                          :resolved resolved
                           :thread-id thread-id :reply-to-id reply-to-id)
                     entries))))))))
 

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -58,6 +58,13 @@ list of repository-relative file paths the user has flagged as done.
 :existing holds review comments already posted to the PR on GitHub,
 fetched once at session start and shown read-only as overlays.")
 
+(defvar my-forge-ediff-review--cards-collapsed nil
+  "When non-nil, inline comment cards render as one-line summaries.
+Shared across every ediff revision buffer of the session so
+`my-forge-ediff-review-toggle-cards' folds or unfolds them all at once.
+Reset to nil when a session starts so an earlier fold never carries
+over into a new review.")
+
 ;;;; Ediff control & navigation
 
 ;; NOTE: `ediff-window-setup-function' is set to `ediff-setup-windows-plain'
@@ -137,6 +144,10 @@ launches multi-file ediff between PR base and head."
                   :memos nil
                   :reviewed nil
                   :existing nil))
+      ;; Start every review with cards unfolded; the fold flag is global,
+      ;; so without this a stray `c' in an earlier review would leave this
+      ;; one showing only one-line summaries.
+      (setq my-forge-ediff-review--cards-collapsed nil)
       (message
        "Review session for PR #%s started. C-c M c to comment, C-c M C to submit."
        (oref pullreq number))
@@ -213,11 +224,6 @@ Bodies are word-wrapped to this width; the card grows wider only when a
 header (author and timestamp) does not fit."
   :type 'integer
   :group 'my-forge-ediff-review)
-
-(defvar my-forge-ediff-review--cards-collapsed nil
-  "When non-nil, inline comment cards render as one-line summaries.
-Shared across every ediff revision buffer of the session so
-`my-forge-ediff-review-toggle-cards' folds or unfolds them all at once.")
 
 (defface my-forge-ediff-review-comment-face
   '((((background light)) :background "#fff8c5" :foreground "#24292f")

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -170,7 +170,7 @@ forges resolve to nil so ghub falls back to its default host."
              id
              isResolved path line originalLine diffSide
              comments(first:100){
-               nodes{ databaseId body author{login} }
+               nodes{ databaseId body createdAt author{login} }
              }
            }
          }
@@ -207,6 +207,18 @@ Runs asynchronously; failures are reported but never abort the review."
 
 ;;;; Overlays in ediff buffers
 
+(defcustom my-forge-ediff-review-card-width 72
+  "Inner content width, in columns, of an inline review comment card.
+Bodies are word-wrapped to this width; the card grows wider only when a
+header (author and timestamp) does not fit."
+  :type 'integer
+  :group 'my-forge-ediff-review)
+
+(defvar my-forge-ediff-review--cards-collapsed nil
+  "When non-nil, inline comment cards render as one-line summaries.
+Shared across every ediff revision buffer of the session so
+`my-forge-ediff-review-toggle-cards' folds or unfolds them all at once.")
+
 (defface my-forge-ediff-review-comment-face
   '((((background light)) :background "#fff8c5" :foreground "#24292f")
     (((background dark))  :background "#3a3a00" :foreground "#ffffff"))
@@ -232,34 +244,30 @@ Runs asynchronously; failures are reported but never abort the review."
      ((equal rev (plist-get s :base-rev)) "LEFT")
      ((equal rev (plist-get s :head-rev)) "RIGHT"))))
 
-(defun my-forge-ediff-review--format-overlay-body (label body)
-  "Indent every line of BODY for inline overlay display under LABEL."
-  (mapconcat (lambda (l) (concat "    " label " " l))
-             (split-string body "\n")
-             "\n"))
-
-(defun my-forge-ediff-review--put-overlay (buf line label body face)
-  "Append BODY as a highlighted after-string overlay below LINE in BUF.
-LABEL prefixes each body line (e.g. \"|\" for comments, \"memo\" for
-memos) and FACE highlights the text.  The source line is left untouched;
-only the appended text is highlighted.  The overlay is anchored at
-end-of-line so it does not shift `display-line-numbers-mode' or
-`nlinum-mode' counts."
+(defun my-forge-ediff-review--put-overlay (buf line glyph header body face)
+  "Show BODY as a boxed annotation card below LINE in BUF.
+GLYPH marks the entry kind, HEADER titles the card (author + timestamp
+for existing comments, or a kind label for comments and memos) and FACE
+paints the whole card.  The source line is untouched: the card is an
+overlay `after-string' on a zero-width overlay anchored at end-of-line,
+so it never shifts `display-line-numbers-mode' or `nlinum-mode' counts.
+When `my-forge-ediff-review--cards-collapsed' is non-nil the card is a
+one-line summary instead of the full box."
   (with-current-buffer buf
     (save-excursion
       (goto-char (point-min))
       (forward-line (1- line))
       (let* ((eol (line-end-position))
-             (ov (make-overlay eol eol nil t nil)))
+             (ov (make-overlay eol eol nil t nil))
+             (card (my-forge-ediff-review-model-format-card
+                    glyph header body my-forge-ediff-review-card-width
+                    my-forge-ediff-review--cards-collapsed)))
         (overlay-put ov 'my-forge-ediff-review t)
         (overlay-put ov 'priority 100)
+        ;; Leave the leading newline unpropertized so no highlighted strip
+        ;; bleeds to the window edge before the box; the card owns the face.
         (overlay-put ov 'after-string
-                     (propertize
-                      (concat
-                       "\n"
-                       (my-forge-ediff-review--format-overlay-body
-                        label body))
-                      'face face))))))
+                     (concat "\n" (propertize card 'face face)))))))
 
 (defun my-forge-ediff-review--clear-overlays (&optional buf)
   "Remove all review overlays from BUF (defaults to current buffer)."
@@ -280,34 +288,41 @@ end-of-line so it does not shift `display-line-numbers-mode' or
          (plist-get my-forge-ediff-review--session :existing) file side)
         (my-forge-ediff-review--put-side-overlays
          (plist-get my-forge-ediff-review--session :comments)
-         file side "|" 'my-forge-ediff-review-comment-face)
+         file side "✎" "Comment" 'my-forge-ediff-review-comment-face)
         (my-forge-ediff-review--put-side-overlays
          (plist-get my-forge-ediff-review--session :memos)
-         file side "memo" 'my-forge-ediff-review-memo-face)))))
+         file side "▤" "Memo" 'my-forge-ediff-review-memo-face)))))
 
 (defun my-forge-ediff-review--put-existing-overlays (entries file side)
   "Overlay existing review comments in ENTRIES matching FILE and SIDE.
-Each comment is labelled with its author and a resolved marker so it is
-clearly distinguished from the reviewer's own pending comments."
+Each card header carries the author, the comment's posting time and a
+resolved marker so it is clearly distinguished from the reviewer's own
+pending comments."
   (dolist (entry (my-forge-ediff-review-model-entries-for-side
                   entries file side))
-    (my-forge-ediff-review--put-overlay
-     (current-buffer)
-     (plist-get entry :line)
-     (format "%s%s:"
-             (or (plist-get entry :author) "reviewer")
-             (if (plist-get entry :resolved) " (resolved)" ""))
-     (plist-get entry :body)
-     'my-forge-ediff-review-existing-comment-face)))
+    (let* ((author (or (plist-get entry :author) "reviewer"))
+           (time (my-forge-ediff-review-model-format-time
+                  (plist-get entry :created-at)))
+           (resolved (if (plist-get entry :resolved) " (resolved)" ""))
+           (header (concat author
+                           (if (string-empty-p time) "" (concat "  " time))
+                           resolved)))
+      (my-forge-ediff-review--put-overlay
+       (current-buffer)
+       (plist-get entry :line)
+       "◈" header
+       (plist-get entry :body)
+       'my-forge-ediff-review-existing-comment-face))))
 
-(defun my-forge-ediff-review--put-side-overlays (entries file side label face)
-  "Overlay each of ENTRIES matching FILE and SIDE with LABEL and FACE."
+(defun my-forge-ediff-review--put-side-overlays (entries file side glyph header face)
+  "Overlay each of ENTRIES matching FILE and SIDE as a GLYPH/HEADER card.
+FACE paints the card."
   (dolist (entry (my-forge-ediff-review-model-entries-for-side
                   entries file side))
     (my-forge-ediff-review--put-overlay
      (current-buffer)
      (plist-get entry :line)
-     label
+     glyph header
      (plist-get entry :body)
      face)))
 
@@ -318,6 +333,17 @@ clearly distinguished from the reviewer's own pending comments."
       (with-current-buffer buf
         (my-forge-ediff-review--reapply-overlays))))
   (my-forge-ediff-review--refresh-sidebar))
+
+(defun my-forge-ediff-review-toggle-cards ()
+  "Fold or unfold every inline comment card in the review.
+Folded cards shrink to a one-line summary so a diff dense with comments
+stays readable; unfolding restores the full boxed body."
+  (interactive)
+  (setq my-forge-ediff-review--cards-collapsed
+        (not my-forge-ediff-review--cards-collapsed))
+  (my-forge-ediff-review--refresh-all-buffers)
+  (message "Review comment cards %s"
+           (if my-forge-ediff-review--cards-collapsed "folded" "unfolded")))
 
 (defvar-local my-forge-ediff-review--keys-installed nil
   "Non-nil once review navigation keys are installed in this buffer.
@@ -337,6 +363,7 @@ file/rev locals set by `my-magit-ediff--create-revision-buffer'."
       (define-key map (kbd "m") #'my-forge-ediff-review-add-memo)
       (define-key map (kbd "r") #'my-forge-ediff-review-reply-to-comment)
       (define-key map (kbd "d") #'my-forge-ediff-review-toggle-reviewed)
+      (define-key map (kbd "c") #'my-forge-ediff-review-toggle-cards)
       (define-key map (kbd "n") #'my-forge-ediff-review-next-diff)
       (define-key map (kbd "p") #'my-forge-ediff-review-prev-diff)
       (define-key map (kbd "q") #'my-forge-ediff-review-quit-ediff)

--- a/tests/my-forge-ediff-review-model-test.el
+++ b/tests/my-forge-ediff-review-model-test.el
@@ -361,6 +361,71 @@ LOCATION is an alist providing the thread-level `path', `line',
                "…" (my-forge-ediff-review-model--card-summary
                     "✎" "Comment" "only one line"))))
 
+;;;; Card rendering (golden — exact input/output)
+
+;; These pin the full rendered layout byte-for-byte so any change to the
+;; box drawing, padding, wrapping or fold summary is caught, not just its
+;; prefix.  Regenerate with scripts if the layout is intentionally changed.
+
+(ert-deftest review-model-card-golden-expanded-single-line-body ()
+  (should (equal
+           (my-forge-ediff-review-model-format-card "✎" "Comment" "hi there" 10 nil)
+           "╭────────────╮
+│ ✎ Comment  │
+├────────────┤
+│ hi there   │
+╰────────────╯")))
+
+(ert-deftest review-model-card-golden-expanded-body-wraps-to-width ()
+  (should (equal
+           (my-forge-ediff-review-model-format-card "✎" "Comment" "the quick brown fox jumps" 10 nil)
+           "╭────────────╮
+│ ✎ Comment  │
+├────────────┤
+│ the quick  │
+│ brown fox  │
+│ jumps      │
+╰────────────╯")))
+
+(ert-deftest review-model-card-golden-expanded-preserves-blank-paragraph-line ()
+  (should (equal
+           (my-forge-ediff-review-model-format-card "◈" "octocat" "para one\n\npara two" 12 nil)
+           "╭──────────────╮
+│ ◈ octocat    │
+├──────────────┤
+│ para one     │
+│              │
+│ para two     │
+╰──────────────╯")))
+
+(ert-deftest review-model-card-golden-expanded-grows-when-header-wider-than-width ()
+  (should (equal
+           (my-forge-ediff-review-model-format-card "◈" "verylongauthor 2026-01-15 10:30" "hi" 8 nil)
+           "╭───────────────────────────────────╮
+│ ◈ verylongauthor 2026-01-15 10:30 │
+├───────────────────────────────────┤
+│ hi                                │
+╰───────────────────────────────────╯")))
+
+(ert-deftest review-model-card-golden-expanded-empty-body ()
+  (should (equal
+           (my-forge-ediff-review-model-format-card "✎" "Comment" "" 10 nil)
+           "╭────────────╮
+│ ✎ Comment  │
+├────────────┤
+│            │
+╰────────────╯")))
+
+(ert-deftest review-model-card-golden-collapsed-multi-line ()
+  (should (equal
+           (my-forge-ediff-review-model-format-card "✎" "Comment" "first line\nsecond" 20 t)
+           "▸ ✎ Comment: first lin… ")))
+
+(ert-deftest review-model-card-golden-collapsed-single-line ()
+  (should (equal
+           (my-forge-ediff-review-model-format-card "▤" "Memo" "just one" 20 t)
+           "▸ ▤ Memo: just one      ")))
+
 ;;;; API host resolution (github.com and GitHub Enterprise)
 
 (ert-deftest review-model-resolve-host-should-return-github-apihost ()

--- a/tests/my-forge-ediff-review-model-test.el
+++ b/tests/my-forge-ediff-review-model-test.el
@@ -138,11 +138,13 @@
        (reviewThreads
         (nodes . ,thread-nodes)))))))
 
-(defun my-forge-ediff-review-model-test--comment (body author)
-  "Build one review comment node carrying BODY and AUTHOR login.
+(defun my-forge-ediff-review-model-test--comment (body author &optional created-at)
+  "Build one review comment node carrying BODY, AUTHOR login and CREATED-AT.
 GitHub exposes `path'/`line'/`diffSide' on the thread, so a comment node
-holds only the body and author."
-  `((body . ,body) (author (login . ,author))))
+holds only the body, author and (when given) the ISO8601 `createdAt'."
+  `((body . ,body)
+    ,@(when created-at `((createdAt . ,created-at)))
+    (author (login . ,author))))
 
 (defun my-forge-ediff-review-model-test--thread (resolved location comment-nodes)
   "Build one reviewThread node with RESOLVED, LOCATION and COMMENT-NODES.
@@ -257,6 +259,96 @@ LOCATION is an alist providing the thread-level `path', `line',
     (should (equal "THREAD_kw1" (plist-get (car entries) :thread-id)))
     (should (= 555 (plist-get (car entries) :reply-to-id)))
     (should (= 555 (plist-get (cadr entries) :reply-to-id)))))
+
+(ert-deftest review-model-should-parse-comment-created-at ()
+  (let* ((response
+          (my-forge-ediff-review-model-test--threads-response
+           (vector
+            (my-forge-ediff-review-model-test--thread
+             :json-false
+             '((path . "a.el") (line . 3) (diffSide . "RIGHT"))
+             (vector (my-forge-ediff-review-model-test--comment
+                      "hi" "octocat" "2026-01-15T10:30:00Z"))))))
+         (entry (car (my-forge-ediff-review-model-parse-review-threads
+                      response))))
+    (should (equal "2026-01-15T10:30:00Z" (plist-get entry :created-at)))))
+
+;;;; Timestamp formatting
+
+(ert-deftest review-model-format-time-should-format-iso ()
+  ;; Pin the zone so the local rendering is deterministic under any TZ.
+  (let ((process-environment (cons "TZ=UTC" process-environment)))
+    (should (equal "2026-01-15 10:30"
+                   (my-forge-ediff-review-model-format-time
+                    "2026-01-15T10:30:00Z")))))
+
+(ert-deftest review-model-format-time-should-be-empty-for-nil-or-blank ()
+  (should (equal "" (my-forge-ediff-review-model-format-time nil)))
+  (should (equal "" (my-forge-ediff-review-model-format-time ""))))
+
+;;;; Card text padding and wrapping
+
+(ert-deftest review-model-pad-should-fill-to-width ()
+  (should (equal "ab   " (my-forge-ediff-review-model--pad "ab" 5)))
+  (should (= 5 (string-width (my-forge-ediff-review-model--pad "ab" 5)))))
+
+(ert-deftest review-model-pad-should-not-shrink-long-strings ()
+  (should (equal "abcdef" (my-forge-ediff-review-model--pad "abcdef" 3))))
+
+(ert-deftest review-model-pad-should-count-wide-glyphs-as-two ()
+  ;; A full-width character occupies two columns, so only one pad space
+  ;; is needed to reach width 4.
+  (should (= 4 (string-width (my-forge-ediff-review-model--pad "あ" 4)))))
+
+(ert-deftest review-model-wrap-should-not-exceed-width ()
+  (let ((lines (my-forge-ediff-review-model--wrap-text
+                "the quick brown fox jumps over the lazy dog" 12)))
+    (dolist (l lines)
+      (should (<= (string-width l) 12)))))
+
+(ert-deftest review-model-wrap-should-keep-blank-paragraph-lines ()
+  (let ((lines (my-forge-ediff-review-model--wrap-text "a\n\nb" 20)))
+    (should (member "" lines))))
+
+(ert-deftest review-model-wrap-should-emit-overlong-word-alone ()
+  (let ((lines (my-forge-ediff-review-model--wrap-text
+                "short verylongwordthatexceeds end" 8)))
+    (should (member "verylongwordthatexceeds" lines))))
+
+;;;; Card rendering
+
+(ert-deftest review-model-card-should-be-a-rectangle ()
+  ;; Every visual line must share the same display width so the background
+  ;; face paints a clean rectangle (the annotate.el invariant).
+  (let* ((card (my-forge-ediff-review-model-format-card
+                "◈" "octocat  2026-01-15 10:30 (resolved)"
+                "line one\n\ntwo two two" 40))
+         (widths (mapcar #'string-width (split-string card "\n"))))
+    (should (= 1 (length (delete-dups (copy-sequence widths)))))))
+
+(ert-deftest review-model-card-should-contain-glyph-and-header ()
+  (let ((card (my-forge-ediff-review-model-format-card
+               "◈" "octocat" "body" 40)))
+    (should (string-match-p "◈" card))
+    (should (string-match-p "octocat" card))))
+
+(ert-deftest review-model-card-should-render-borders-even-when-empty ()
+  (let ((card (my-forge-ediff-review-model-format-card "◈" "octocat" "" 40)))
+    (should (string-prefix-p "╭" card))
+    (should (string-suffix-p "╯" (car (last (split-string card "\n")))))))
+
+(ert-deftest review-model-card-line-count-should-match-body ()
+  ;; 3 chrome lines (top, header, separator) + N body lines + 1 bottom.
+  (let* ((card (my-forge-ediff-review-model-format-card
+                "◈" "h" "a\nb\nc" 40))
+         (lines (split-string card "\n")))
+    (should (= (+ 3 3 1) (length lines)))))
+
+(ert-deftest review-model-card-collapsed-should-be-one-line ()
+  (let ((card (my-forge-ediff-review-model-format-card
+               "✎" "Comment" "first line\nsecond line" 40 t)))
+    (should-not (string-match-p "\n" card))
+    (should (string-match-p "first line" card))))
 
 ;;;; API host resolution (github.com and GitHub Enterprise)
 

--- a/tests/my-forge-ediff-review-model-test.el
+++ b/tests/my-forge-ediff-review-model-test.el
@@ -348,7 +348,18 @@ LOCATION is an alist providing the thread-level `path', `line',
   (let ((card (my-forge-ediff-review-model-format-card
                "✎" "Comment" "first line\nsecond line" 40 t)))
     (should-not (string-match-p "\n" card))
-    (should (string-match-p "first line" card))))
+    (should (string-match-p "first line" card))
+    ;; A fold affordance marks it as collapsed, not broken.
+    (should (string-match-p "▸" card))))
+
+(ert-deftest review-model-collapsed-summary-should-mark-hidden-lines ()
+  ;; A multi-line body gets a trailing ellipsis; a single-line body does not.
+  (should (string-suffix-p
+           "…" (my-forge-ediff-review-model--card-summary
+                "✎" "Comment" "one\ntwo")))
+  (should-not (string-suffix-p
+               "…" (my-forge-ediff-review-model--card-summary
+                    "✎" "Comment" "only one line"))))
 
 ;;;; API host resolution (github.com and GitHub Enterprise)
 


### PR DESCRIPTION
## Summary
This change adds visual formatting for inline review comments displayed in ediff buffers. Comments are now rendered as box-drawn cards with proper text wrapping and padding, and can be toggled between expanded and collapsed (summary) views.

## Key Changes

- **Card formatting infrastructure**: Added helper functions for text manipulation:
  - `my-forge-ediff-review-model--pad`: Right-pads strings to a specified display width, accounting for wide glyphs
  - `my-forge-ediff-review-model--wrap-text`: Word-wraps text to a specified column width while preserving paragraph breaks
  - `my-forge-ediff-review-model--card-summary`: Extracts a one-line summary from card content

- **Card rendering**: Implemented `my-forge-ediff-review-model-format-card` to generate box-drawn annotation cards with:
  - Unicode box-drawing characters (╭─╮│├┤╰) for clean rectangular borders
  - Consistent padding across all lines so background faces paint clean rectangles
  - Support for both expanded (full box) and collapsed (one-line summary) modes
  - Configurable inner content width via `my-forge-ediff-review-card-width` custom variable

- **Timestamp support**: 
  - Added `my-forge-ediff-review-model-format-time` to convert GitHub ISO8601 timestamps to readable local time format
  - Updated GraphQL query to fetch `createdAt` field from comments
  - Extended review thread parsing to include `created-at` in entry plists

- **UI improvements**:
  - Replaced simple text labels with Unicode glyphs (✎ for comments, ▤ for memos, ◈ for existing comments)
  - Card headers now display author, timestamp, and resolved status for existing comments
  - Added `my-forge-ediff-review-toggle-cards` command (bound to `c` key) to fold/unfold all cards at once
  - Introduced `my-forge-ediff-review--cards-collapsed` session variable to synchronize card state across all ediff buffers

- **Overlay refactoring**: Simplified `my-forge-ediff-review--put-overlay` to use the new card formatting system instead of simple line-prefixed text

## Implementation Details

- All card formatting functions are pure string transformations, making them easily unit-testable without requiring ediff
- Text wrapping respects hard breaks (newlines) to preserve markdown paragraph structure
- Wide glyphs (e.g., CJK characters) are correctly measured using `string-width` for accurate padding
- Collapsed cards use a truncation marker (…) when content exceeds available width
- The zero-width overlay anchor at end-of-line ensures line numbers are never shifted by card display

## Testing
Comprehensive unit tests added covering:
- Timestamp parsing and formatting
- Text padding with wide glyphs
- Text wrapping behavior
- Card rendering (rectangle invariant, border rendering, line counts)
- Collapsed card formatting

https://claude.ai/code/session_01X9xQhdePCjZNpEHJLBsKfx