### PR TITLE
Soften ediff diff faces to preserve syntax highlighting

### DIFF
--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -223,6 +223,51 @@ Runs asynchronously; failures are reported but never abort the review."
   "Face for existing review comments already posted to the PR on GitHub."
   :group 'my-forge-ediff-review)
 
+(defcustom my-forge-ediff-review-dim-diff-faces t
+  "When non-nil, soften ediff's diff highlight faces in review buffers.
+Ediff's default `ediff-current-diff-*' and `ediff-fine-diff-*' faces
+paint an opaque background and override the foreground, which hides the
+buffer's own syntax highlighting.  While a review session is active
+those faces are remapped, buffer-locally, to a background-only spec so
+the font-lock foreground stays visible and code remains readable.  The
+remap is scoped to the ediff revision buffers, so ediff used outside a
+review keeps its normal, stronger highlighting."
+  :type 'boolean
+  :group 'my-forge-ediff-review)
+
+(defconst my-forge-ediff-review--dim-diff-faces
+  '((ediff-current-diff-A        . (:background "#3d2529"))
+    (ediff-current-diff-B        . (:background "#1f3325"))
+    (ediff-current-diff-C        . (:background "#2f2f1c"))
+    (ediff-current-diff-Ancestor . (:background "#2f2f1c"))
+    (ediff-fine-diff-A           . (:background "#5a2c33"))
+    (ediff-fine-diff-B           . (:background "#2c4a35"))
+    (ediff-fine-diff-C           . (:background "#4a4a24"))
+    (ediff-fine-diff-Ancestor    . (:background "#4a4a24"))
+    (ediff-even-diff-A           . (:background "#0f333d"))
+    (ediff-even-diff-B           . (:background "#0f333d"))
+    (ediff-even-diff-C           . (:background "#0f333d"))
+    (ediff-even-diff-Ancestor    . (:background "#0f333d"))
+    (ediff-odd-diff-A            . (:background "#0f333d"))
+    (ediff-odd-diff-B            . (:background "#0f333d"))
+    (ediff-odd-diff-C            . (:background "#0f333d"))
+    (ediff-odd-diff-Ancestor     . (:background "#0f333d")))
+  "Alist mapping ediff diff faces to their softened remap spec.
+Each spec sets only a background, so the buffer's font-lock foreground —
+its syntax highlighting — shows through the diff highlight.  Tuned for
+the solarized-dark background used in this configuration.")
+
+(defun my-forge-ediff-review--dim-diff-faces ()
+  "Buffer-locally soften ediff's diff faces in the current revision buffer.
+Uses `face-remap-set-base' so each face keeps only a subtle background,
+which lets syntax highlighting remain visible underneath the diff
+highlight.  No-op unless a review session is active and
+`my-forge-ediff-review-dim-diff-faces' is non-nil."
+  (when (and my-forge-ediff-review-dim-diff-faces
+             my-forge-ediff-review--session)
+    (dolist (pair my-forge-ediff-review--dim-diff-faces)
+      (face-remap-set-base (car pair) (cdr pair)))))
+
 (defun my-forge-ediff-review--side-for-rev (rev)
   "Return \"LEFT\" / \"RIGHT\" for REV in the current session, or nil."
   (let ((s my-forge-ediff-review--session))
@@ -346,6 +391,7 @@ file/rev locals set by `my-magit-ediff--create-revision-buffer'."
   "Apply overlays and install nav/comment keys in the current revision buffer."
   (my-forge-ediff-review--reapply-overlays)
   (my-forge-ediff-review--setup-revision-keys)
+  (my-forge-ediff-review--dim-diff-faces)
   (my-forge-ediff-review--refresh-sidebar))
 
 ;; Hook so that comments persist and review keys exist when ediff

--- a/tests/my-forge-ediff-review-test.el
+++ b/tests/my-forge-ediff-review-test.el
@@ -95,5 +95,38 @@
       (should (= 1 (length memos)))
       (should (equal "m2" (plist-get (car memos) :body))))))
 
+(ert-deftest my-forge-ediff-review-dims-diff-faces-when-session-active ()
+  "Softening remaps every diff face to a background-only spec locally."
+  (skip-unless my-forge-ediff-review-test--available)
+  (with-temp-buffer
+    (my-forge-ediff-review-test--with-session (list :comments nil :memos nil)
+      (let ((my-forge-ediff-review-dim-diff-faces t))
+        (my-forge-ediff-review--dim-diff-faces)
+        (should (local-variable-p 'face-remapping-alist))
+        (dolist (pair my-forge-ediff-review--dim-diff-faces)
+          ;; The face is remapped and the remap only touches the
+          ;; background, leaving the font-lock foreground intact.
+          (should (assq (car pair) face-remapping-alist))
+          (should (plist-get (cdr pair) :background))
+          (should-not (plist-get (cdr pair) :foreground)))))))
+
+(ert-deftest my-forge-ediff-review-does-not-dim-when-disabled ()
+  "No remap happens when softening is turned off."
+  (skip-unless my-forge-ediff-review-test--available)
+  (with-temp-buffer
+    (my-forge-ediff-review-test--with-session (list :comments nil :memos nil)
+      (let ((my-forge-ediff-review-dim-diff-faces nil))
+        (my-forge-ediff-review--dim-diff-faces)
+        (should-not (assq 'ediff-current-diff-A face-remapping-alist))))))
+
+(ert-deftest my-forge-ediff-review-does-not-dim-without-session ()
+  "No remap happens outside an active review session."
+  (skip-unless my-forge-ediff-review-test--available)
+  (with-temp-buffer
+    (my-forge-ediff-review-test--with-session nil
+      (let ((my-forge-ediff-review-dim-diff-faces t))
+        (my-forge-ediff-review--dim-diff-faces)
+        (should-not (assq 'ediff-current-diff-A face-remapping-alist))))))
+
 (provide 'my-forge-ediff-review-test)
 ;;; my-forge-ediff-review-test.el ends here


### PR DESCRIPTION
## Summary
Add an optional feature to reduce the visual intensity of ediff's diff highlight faces during code reviews, allowing syntax highlighting to remain visible underneath the diff colors.

## Key Changes
- **New customization option** `my-forge-ediff-review-dim-diff-faces`: Toggle to enable/disable the softening behavior (defaults to `t`)
- **New face remap table** `my-forge-ediff-review--dim-diff-faces`: Defines background-only color specs for all ediff diff faces, tuned for solarized-dark theme
- **New function** `my-forge-ediff-review--dim-diff-faces`: Applies buffer-local face remaps using `face-remap-set-base` when a review session is active and the feature is enabled
- **Integration point**: Call the new function in `my-forge-ediff-review--setup-revision-buffer` to apply remaps when setting up revision buffers
- **Comprehensive test coverage**: Three new tests verify the feature works when enabled, is skipped when disabled, and is skipped outside an active session

## Implementation Details
- Face remaps are applied buffer-locally only to revision buffers, so ediff used outside a review session retains its normal highlighting
- Each remapped face spec contains only a `:background` property, allowing the buffer's font-lock foreground (syntax highlighting) to show through
- The feature is guarded by both the customization flag and the presence of an active review session (`my-forge-ediff-review--session`)

https://claude.ai/code/session_01XidQFxT7Z5R5QXX1inHDX6