### PR TITLE
Make C-c t a focus-aware three-state vterm toggle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,5 @@ jobs:
           -l tests/my-forge-ediff-review-model-test.el \
           -l tests/my-forge-ediff-review-test.el \
           -l tests/my-magit-ediff-window-test.el \
+          -l tests/my-vterm-toggle-test.el \
           -f ert-run-tests-batch-and-exit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,5 @@ jobs:
       run: |
         emacs -Q --batch --eval '(progn (require (quote package)) (package-initialize))' \
           -L lisp -l ert \
-          -l tests/my-forge-ediff-review-model-test.el \
-          -l tests/my-forge-ediff-review-test.el \
-          -l tests/my-magit-ediff-window-test.el \
-          -l tests/my-vterm-toggle-test.el \
+          $(printf -- '-l %s ' tests/*.el) \
           -f ert-run-tests-batch-and-exit

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -1270,46 +1270,14 @@ Changes AFTER the selected commit are shown in the fringe (exclusive)."
 (use-package vterm-toggle :ensure t
   :after (vterm)
   :config
-  ;; Hide claude-code-ide session buffers from vterm-toggle so that pressing the
-  ;; toggle key never lands on them. The session-buffer-p check fails for vterm
-  ;; buffers that have been renamed via `vterm-buffer-name-string', so also
-  ;; consult `claude-code-ide--processes' to identify them by process-buffer.
-  (defun my-vterm-toggle-claude-code-ide-buffer-p (buffer)
-    "Return non-nil when BUFFER hosts a claude-code-ide session."
-    (or (and (fboundp 'claude-code-ide--session-buffer-p)
-             (claude-code-ide--session-buffer-p buffer))
-        (and (boundp 'claude-code-ide--processes)
-             (cl-loop for proc being the hash-values of claude-code-ide--processes
-                      when (and (process-live-p proc)
-                                (eq (process-buffer proc) buffer))
-                      return t))))
-  (defun my-vterm-toggle-non-claude-code-ide-buffer-p (buffer)
-    "Return non-nil when BUFFER is not a claude-code-ide session buffer."
-    (not (my-vterm-toggle-claude-code-ide-buffer-p buffer)))
+  ;; The toggle dispatch and the claude-code-ide predicates live in
+  ;; lisp/my-vterm-toggle.el so that tests/my-vterm-toggle-test.el can load
+  ;; them without pulling in the whole init.
+  (require 'my-vterm-toggle)
+  ;; Hide claude-code-ide session buffers from vterm-toggle so that pressing
+  ;; the toggle key never lands on them.
   (add-to-list 'vterm-toggle-togglable-buffer-functions
                #'my-vterm-toggle-non-claude-code-ide-buffer-p)
-  ;; Toggle to a non-claude vterm. When the user is currently inside a
-  ;; claude-code-ide buffer, do not hide it; instead pop up another vterm (or
-  ;; spawn a new one) so the claude-code-ide window stays out of the way.
-  (defun my-vterm-toggle (&optional args)
-    "Vterm toggle that ignores claude-code-ide session buffers.
-Optional argument ARGS is passed through as the prefix argument."
-    (interactive "P")
-    (cond
-     ((my-vterm-toggle-claude-code-ide-buffer-p (current-buffer))
-      (vterm-toggle-show))
-     ((or (derived-mode-p 'vterm-mode)
-          (and (vterm-toggle--get-window)
-               vterm-toggle-hide-method))
-      (if (equal (prefix-numeric-value args) 1)
-          (vterm-toggle-hide)
-        (vterm vterm-buffer-name)))
-     ((equal (prefix-numeric-value args) 1)
-      (vterm-toggle-show))
-     ((equal (prefix-numeric-value args) 4)
-      (let ((vterm-toggle-fullscreen-p
-             (not vterm-toggle-fullscreen-p)))
-        (vterm-toggle-show)))))
   :bind
   ("\C-c t" . 'my-vterm-toggle)
   ;; ("\C-c t" . 'vterm-toggle)

--- a/lisp/my-vterm-toggle.el
+++ b/lisp/my-vterm-toggle.el
@@ -1,0 +1,65 @@
+;;; my-vterm-toggle.el --- vterm toggle aware of claude-code-ide -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; A vterm-toggle dispatch that skips claude-code-ide sessions.
+;; claude-code-ide sessions run inside vterm buffers, so the stock
+;; toggle happily lands on (or hides) a Claude session.  The predicates
+;; here identify those buffers so the toggle skips them.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(declare-function vterm "vterm")
+(declare-function vterm-toggle-show "vterm-toggle")
+(declare-function vterm-toggle-hide "vterm-toggle")
+(declare-function vterm-toggle--get-window "vterm-toggle")
+(declare-function claude-code-ide--session-buffer-p "claude-code-ide")
+
+(defvar vterm-buffer-name)
+(defvar vterm-toggle-hide-method)
+(defvar vterm-toggle-fullscreen-p)
+(defvar claude-code-ide--processes)
+
+(defun my-vterm-toggle-claude-code-ide-buffer-p (buffer)
+  "Return non-nil when BUFFER hosts a claude-code-ide session.
+The session-buffer-p check fails for vterm buffers that have been
+renamed via `vterm-buffer-name-string', so also consult
+`claude-code-ide--processes' to identify them by process-buffer."
+  (or (and (fboundp 'claude-code-ide--session-buffer-p)
+           (claude-code-ide--session-buffer-p buffer))
+      (and (boundp 'claude-code-ide--processes)
+           (cl-loop for proc being the hash-values of claude-code-ide--processes
+                    when (and (process-live-p proc)
+                              (eq (process-buffer proc) buffer))
+                    return t))))
+
+(defun my-vterm-toggle-non-claude-code-ide-buffer-p (buffer)
+  "Return non-nil when BUFFER is not a claude-code-ide session buffer."
+  (not (my-vterm-toggle-claude-code-ide-buffer-p buffer)))
+
+(defun my-vterm-toggle (&optional args)
+  "Vterm toggle that ignores claude-code-ide session buffers.
+When the user is currently inside a claude-code-ide buffer, do not
+hide it; instead pop up another vterm \(or spawn a new one) so the
+claude-code-ide window stays out of the way.  Optional argument ARGS
+is passed through as the prefix argument."
+  (interactive "P")
+  (cond
+   ((my-vterm-toggle-claude-code-ide-buffer-p (current-buffer))
+    (vterm-toggle-show))
+   ((or (derived-mode-p 'vterm-mode)
+        (and (vterm-toggle--get-window)
+             vterm-toggle-hide-method))
+    (if (equal (prefix-numeric-value args) 1)
+        (vterm-toggle-hide)
+      (vterm vterm-buffer-name)))
+   ((equal (prefix-numeric-value args) 1)
+    (vterm-toggle-show))
+   ((equal (prefix-numeric-value args) 4)
+    (let ((vterm-toggle-fullscreen-p
+           (not vterm-toggle-fullscreen-p)))
+      (vterm-toggle-show)))))
+
+(provide 'my-vterm-toggle)
+;;; my-vterm-toggle.el ends here

--- a/lisp/my-vterm-toggle.el
+++ b/lisp/my-vterm-toggle.el
@@ -1,10 +1,20 @@
-;;; my-vterm-toggle.el --- vterm toggle aware of claude-code-ide -*- lexical-binding: t; -*-
+;;; my-vterm-toggle.el --- vterm toggle aware of claude-code-ide and frames -*- lexical-binding: t; -*-
 
 ;;; Commentary:
-;; A vterm-toggle dispatch that skips claude-code-ide sessions.
-;; claude-code-ide sessions run inside vterm buffers, so the stock
-;; toggle happily lands on (or hides) a Claude session.  The predicates
-;; here identify those buffers so the toggle skips them.
+;; A vterm-toggle dispatch that fixes two shortcomings of the stock
+;; `vterm-toggle' command for this setup:
+;;
+;; 1. claude-code-ide sessions run inside vterm buffers, so the stock
+;;    toggle happily lands on (or hides) a Claude session.  The
+;;    predicates here identify those buffers so the toggle skips them.
+;;
+;; 2. `vterm-toggle--get-window' only inspects the selected frame.  When
+;;    the vterm buffer is visible on another frame, the stock dispatch
+;;    falls through to `vterm-toggle-show', whose `pop-to-buffer' path
+;;    can select the other frame's window without transferring input
+;;    focus; a follow-up toggle then deletes that window.  The dispatch
+;;    here detects a vterm window on another visible frame and moves
+;;    input focus to it instead.
 
 ;;; Code:
 
@@ -14,6 +24,7 @@
 (declare-function vterm-toggle-show "vterm-toggle")
 (declare-function vterm-toggle-hide "vterm-toggle")
 (declare-function vterm-toggle--get-window "vterm-toggle")
+(declare-function vterm-toggle-togglable-buffer-p "vterm-toggle")
 (declare-function claude-code-ide--session-buffer-p "claude-code-ide")
 
 (defvar vterm-buffer-name)
@@ -38,28 +49,42 @@ renamed via `vterm-buffer-name-string', so also consult
   "Return non-nil when BUFFER is not a claude-code-ide session buffer."
   (not (my-vterm-toggle-claude-code-ide-buffer-p buffer)))
 
+(defun my-vterm-toggle--get-other-frame-window ()
+  "Return a window on another visible frame showing a togglable vterm."
+  (cl-find-if (lambda (window)
+                (and (not (eq (window-frame window) (selected-frame)))
+                     (vterm-toggle-togglable-buffer-p (window-buffer window))))
+              (window-list-1 nil nil 'visible)))
+
 (defun my-vterm-toggle (&optional args)
   "Vterm toggle that ignores claude-code-ide session buffers.
-When the user is currently inside a claude-code-ide buffer, do not
-hide it; instead pop up another vterm \(or spawn a new one) so the
-claude-code-ide window stays out of the way.  Optional argument ARGS
-is passed through as the prefix argument."
+When the vterm is visible on another frame and the selected frame has
+no vterm window, move input focus to that frame instead of hiding or
+re-showing the buffer.  When the user is currently inside a
+claude-code-ide buffer, do not hide it; instead pop up another vterm
+\(or spawn a new one) so the claude-code-ide window stays out of the
+way.  Optional argument ARGS is passed through as the prefix argument."
   (interactive "P")
-  (cond
-   ((my-vterm-toggle-claude-code-ide-buffer-p (current-buffer))
-    (vterm-toggle-show))
-   ((or (derived-mode-p 'vterm-mode)
-        (and (vterm-toggle--get-window)
-             vterm-toggle-hide-method))
-    (if (equal (prefix-numeric-value args) 1)
-        (vterm-toggle-hide)
-      (vterm vterm-buffer-name)))
-   ((equal (prefix-numeric-value args) 1)
-    (vterm-toggle-show))
-   ((equal (prefix-numeric-value args) 4)
-    (let ((vterm-toggle-fullscreen-p
-           (not vterm-toggle-fullscreen-p)))
-      (vterm-toggle-show)))))
+  (let ((other-frame-window (and (not (vterm-toggle--get-window))
+                                 (my-vterm-toggle--get-other-frame-window))))
+    (cond
+     (other-frame-window
+      (select-frame-set-input-focus (window-frame other-frame-window))
+      (select-window other-frame-window))
+     ((my-vterm-toggle-claude-code-ide-buffer-p (current-buffer))
+      (vterm-toggle-show))
+     ((or (derived-mode-p 'vterm-mode)
+          (and (vterm-toggle--get-window)
+               vterm-toggle-hide-method))
+      (if (equal (prefix-numeric-value args) 1)
+          (vterm-toggle-hide)
+        (vterm vterm-buffer-name)))
+     ((equal (prefix-numeric-value args) 1)
+      (vterm-toggle-show))
+     ((equal (prefix-numeric-value args) 4)
+      (let ((vterm-toggle-fullscreen-p
+             (not vterm-toggle-fullscreen-p)))
+        (vterm-toggle-show))))))
 
 (provide 'my-vterm-toggle)
 ;;; my-vterm-toggle.el ends here

--- a/lisp/my-vterm-toggle.el
+++ b/lisp/my-vterm-toggle.el
@@ -1,20 +1,30 @@
 ;;; my-vterm-toggle.el --- vterm toggle aware of claude-code-ide and frames -*- lexical-binding: t; -*-
 
 ;;; Commentary:
-;; A vterm-toggle dispatch that fixes two shortcomings of the stock
+;; A vterm-toggle dispatch that fixes shortcomings of the stock
 ;; `vterm-toggle' command for this setup:
 ;;
 ;; 1. claude-code-ide sessions run inside vterm buffers, so the stock
 ;;    toggle happily lands on (or hides) a Claude session.  The
-;;    predicates here identify those buffers so the toggle skips them.
+;;    predicates here identify those buffers; init-prog.el registers
+;;    them in `vterm-toggle-togglable-buffer-functions' so vterm-toggle
+;;    skips them everywhere.
 ;;
-;; 2. `vterm-toggle--get-window' only inspects the selected frame.  When
-;;    the vterm buffer is visible on another frame, the stock dispatch
-;;    falls through to `vterm-toggle-show', whose `pop-to-buffer' path
-;;    can select the other frame's window without transferring input
-;;    focus; a follow-up toggle then deletes that window.  The dispatch
-;;    here detects a vterm window on another visible frame and moves
-;;    input focus to it instead.
+;; 2. The stock dispatch hides the vterm whenever a vterm window is
+;;    visible on the selected frame, even when focus is on another
+;;    window, and it never looks at other frames at all.  The dispatch
+;;    here implements a three-state machine instead:
+;;    - focus on the vterm: hide it
+;;    - vterm visible elsewhere (another window or another frame):
+;;      move input focus to it
+;;    - vterm not visible: show it
+;;
+;; 3. `vterm-toggle-hide' with the `delete-window' hide method calls
+;;    `delete-window' whenever `window-deletable-p' is non-nil, but that
+;;    predicate returns the symbol `frame' for a frame's sole ordinary
+;;    window, and `delete-window' then signals "Attempt to delete
+;;    minibuffer or sole ordinary window".  The hide path here deletes
+;;    the frame in that case.
 
 ;;; Code:
 
@@ -28,7 +38,6 @@
 (declare-function claude-code-ide--session-buffer-p "claude-code-ide")
 
 (defvar vterm-buffer-name)
-(defvar vterm-toggle-hide-method)
 (defvar vterm-toggle-fullscreen-p)
 (defvar claude-code-ide--processes)
 
@@ -56,35 +65,49 @@ renamed via `vterm-buffer-name-string', so also consult
                      (vterm-toggle-togglable-buffer-p (window-buffer window))))
               (window-list-1 nil nil 'visible)))
 
+(defun my-vterm-toggle--hide-focused-vterm ()
+  "Hide the vterm window that holds input focus.
+When the vterm is the sole ordinary window of its frame,
+`window-deletable-p' returns the symbol `frame' and `vterm-toggle-hide'
+would signal an error from `delete-window'; delete the frame instead.
+On the last visible frame `window-deletable-p' returns nil and
+`vterm-toggle-hide' safely falls back to burying the buffer."
+  (if (eq (window-deletable-p) 'frame)
+      (delete-frame)
+    (vterm-toggle-hide)))
+
 (defun my-vterm-toggle (&optional args)
-  "Vterm toggle that ignores claude-code-ide session buffers.
-When the vterm is visible on another frame and the selected frame has
-no vterm window, move input focus to that frame instead of hiding or
-re-showing the buffer.  When the user is currently inside a
-claude-code-ide buffer, do not hide it; instead pop up another vterm
-\(or spawn a new one) so the claude-code-ide window stays out of the
-way.  Optional argument ARGS is passed through as the prefix argument."
+  "Toggle the vterm as a three-state dispatch.
+Hide the vterm when focus is already on it, move focus to a visible
+vterm window (on this or another frame) otherwise, and show the vterm
+when it is not visible anywhere.  claude-code-ide session buffers are
+not togglable, so the toggle never hides or lands on them.  With
+prefix argument ARGS other than 1 inside a vterm, spawn a new vterm;
+with prefix argument 4 while no vterm is visible, toggle
+`vterm-toggle-fullscreen-p' for this show."
   (interactive "P")
-  (let ((other-frame-window (and (not (vterm-toggle--get-window))
-                                 (my-vterm-toggle--get-other-frame-window))))
+  (let* ((focused-on-vterm (vterm-toggle-togglable-buffer-p (current-buffer)))
+         (current-frame-window (and (not focused-on-vterm)
+                                    (vterm-toggle--get-window)))
+         (other-frame-window (and (not focused-on-vterm)
+                                  (not current-frame-window)
+                                  (my-vterm-toggle--get-other-frame-window))))
     (cond
+     (focused-on-vterm
+      (if (equal (prefix-numeric-value args) 1)
+          (my-vterm-toggle--hide-focused-vterm)
+        (vterm vterm-buffer-name)))
+     (current-frame-window
+      (select-window current-frame-window))
      (other-frame-window
       (select-frame-set-input-focus (window-frame other-frame-window))
       (select-window other-frame-window))
-     ((my-vterm-toggle-claude-code-ide-buffer-p (current-buffer))
-      (vterm-toggle-show))
-     ((or (derived-mode-p 'vterm-mode)
-          (and (vterm-toggle--get-window)
-               vterm-toggle-hide-method))
-      (if (equal (prefix-numeric-value args) 1)
-          (vterm-toggle-hide)
-        (vterm vterm-buffer-name)))
-     ((equal (prefix-numeric-value args) 1)
-      (vterm-toggle-show))
      ((equal (prefix-numeric-value args) 4)
       (let ((vterm-toggle-fullscreen-p
              (not vterm-toggle-fullscreen-p)))
-        (vterm-toggle-show))))))
+        (vterm-toggle-show)))
+     (t
+      (vterm-toggle-show)))))
 
 (provide 'my-vterm-toggle)
 ;;; my-vterm-toggle.el ends here

--- a/tests/my-vterm-toggle-test.el
+++ b/tests/my-vterm-toggle-test.el
@@ -3,17 +3,18 @@
 ;;; Commentary:
 ;; Regression tests for the C-c t vterm toggle dispatch.
 ;;
-;; The bug: `my-vterm-toggle' only looked for a vterm window on the
-;; selected frame (`vterm-toggle--get-window' walks `window-list' of the
-;; selected frame).  When the vterm buffer was visible on ANOTHER frame,
-;; the dispatch fell through to `vterm-toggle-show', whose
-;; `pop-to-buffer' path could select the other frame's window without
-;; transferring input focus, and a follow-up toggle then deleted the
-;; vterm window instead of focusing it.
+;; The dispatch implements a three-state machine:
 ;;
-;; The fix: when a vterm window is visible on another frame and no vterm
-;; window exists on the selected frame, move input focus to that frame
-;; and select the window instead of hiding or re-showing the buffer.
+;; 1. Focus is on a togglable vterm buffer: hide it.  When the vterm is
+;;    the sole ordinary window of its frame, `vterm-toggle-hide' with
+;;    the `delete-window' hide method signals "Attempt to delete
+;;    minibuffer or sole ordinary window" because `window-deletable-p'
+;;    returns the symbol `frame' (truthy) yet `delete-window' rejects a
+;;    sole window.  The dispatch deletes the frame instead.
+;; 2. The vterm is visible but focus is elsewhere (another window on
+;;    the selected frame, or another frame): move focus to the vterm
+;;    window instead of hiding or re-showing it.
+;; 3. The vterm is not visible anywhere: show it.
 ;;
 ;; The tests stub the vterm-toggle collaborators and frame primitives
 ;; with `cl-letf' because batch Emacs cannot create multiple real
@@ -33,7 +34,9 @@
 ;; the symbols a loud default so a test that forgets to stub one fails
 ;; clearly, even when the vterm-toggle package is absent in batch runs.
 (defvar vterm-toggle-hide-method)
-(dolist (collaborator '(vterm-toggle-show
+(defvar vterm-buffer-name)
+(dolist (collaborator '(vterm
+                        vterm-toggle-show
                         vterm-toggle-hide
                         vterm-toggle--get-window
                         vterm-toggle-togglable-buffer-p))
@@ -44,22 +47,33 @@
 
 (defmacro my-vterm-toggle-test--with-stubs (spec &rest body)
   "Run BODY with the toggle collaborators stubbed according to SPEC.
-SPEC is a plist with keys :current-frame-window, :other-frame-window,
-and :claude-buffer-p.  BODY can inspect the recorded action symbols in
-the variable `calls' (in reverse order of invocation)."
+SPEC is a plist with these keys:
+- :focused-on-vterm      current buffer is a togglable vterm
+- :current-frame-window  vterm window on the selected frame
+- :other-frame-window    vterm window on another visible frame
+- :window-deletable      return value of `window-deletable-p'
+BODY can inspect the recorded action symbols in the variable `calls'
+\(in reverse order of invocation)."
   (declare (indent 1))
   `(let ((calls '())
-         (vterm-toggle-hide-method 'delete-window))
-     (cl-letf (((symbol-function 'vterm-toggle--get-window)
+         (vterm-toggle-hide-method 'delete-window)
+         (vterm-buffer-name "*vterm*"))
+     (cl-letf (((symbol-function 'vterm-toggle-togglable-buffer-p)
+                (lambda (_buffer) ',(plist-get spec :focused-on-vterm)))
+               ((symbol-function 'vterm-toggle--get-window)
                 (lambda () ',(plist-get spec :current-frame-window)))
                ((symbol-function 'my-vterm-toggle--get-other-frame-window)
                 (lambda () ',(plist-get spec :other-frame-window)))
-               ((symbol-function 'my-vterm-toggle-claude-code-ide-buffer-p)
-                (lambda (_buffer) ',(plist-get spec :claude-buffer-p)))
+               ((symbol-function 'window-deletable-p)
+                (lambda (&optional _window) ',(plist-get spec :window-deletable)))
+               ((symbol-function 'vterm)
+                (lambda (&rest _) (push 'new-vterm calls)))
                ((symbol-function 'vterm-toggle-show)
                 (lambda (&rest _) (push 'show calls)))
                ((symbol-function 'vterm-toggle-hide)
                 (lambda (&rest _) (push 'hide calls)))
+               ((symbol-function 'delete-frame)
+                (lambda (&rest _) (push 'delete-frame calls)))
                ((symbol-function 'window-frame)
                 (lambda (_window) 'stub-frame))
                ((symbol-function 'select-frame-set-input-focus)
@@ -70,9 +84,53 @@ the variable `calls' (in reverse order of invocation)."
        (with-temp-buffer
          ,@body))))
 
+;;; State 1: focus is on the vterm -> hide.
+
+(ert-deftest my-vterm-toggle-should-hide-when-focused-on-vterm ()
+  (my-vterm-toggle-test--with-stubs
+      (:focused-on-vterm t :current-frame-window stub-window :window-deletable t)
+    (my-vterm-toggle)
+    (should (equal calls '(hide)))))
+
+(ert-deftest my-vterm-toggle-should-delete-frame-when-vterm-is-sole-window ()
+  ;; `window-deletable-p' returns the symbol `frame' for a frame's sole
+  ;; window; `vterm-toggle-hide' would signal an error there.
+  (my-vterm-toggle-test--with-stubs
+      (:focused-on-vterm t :current-frame-window stub-window :window-deletable frame)
+    (my-vterm-toggle)
+    (should (equal calls '(delete-frame)))))
+
+(ert-deftest my-vterm-toggle-should-fall-back-to-hide-on-last-frame ()
+  ;; Sole window on the last visible frame: `window-deletable-p' is nil,
+  ;; so defer to `vterm-toggle-hide' which buries the buffer.
+  (my-vterm-toggle-test--with-stubs
+      (:focused-on-vterm t :current-frame-window stub-window :window-deletable nil)
+    (my-vterm-toggle)
+    (should (equal calls '(hide)))))
+
+(ert-deftest my-vterm-toggle-should-spawn-new-vterm-with-prefix-in-vterm ()
+  (my-vterm-toggle-test--with-stubs
+      (:focused-on-vterm t :current-frame-window stub-window :window-deletable t)
+    (my-vterm-toggle '(4))
+    (should (equal calls '(new-vterm)))))
+
+;;; State 2: vterm visible but focus elsewhere -> focus it.
+
+(ert-deftest my-vterm-toggle-should-focus-vterm-window-on-current-frame ()
+  (my-vterm-toggle-test--with-stubs
+      (:current-frame-window stub-window)
+    (my-vterm-toggle)
+    (should (equal calls '((select-window . stub-window))))))
+
+(ert-deftest my-vterm-toggle-should-not-hide-unfocused-vterm-on-current-frame ()
+  (my-vterm-toggle-test--with-stubs
+      (:current-frame-window stub-window)
+    (my-vterm-toggle)
+    (should-not (memq 'hide calls))))
+
 (ert-deftest my-vterm-toggle-should-focus-frame-showing-vterm-on-other-frame ()
   (my-vterm-toggle-test--with-stubs
-      (:current-frame-window nil :other-frame-window stub-window)
+      (:other-frame-window stub-window)
     (my-vterm-toggle)
     (should (equal calls
                    '((select-window . stub-window)
@@ -80,47 +138,48 @@ the variable `calls' (in reverse order of invocation)."
 
 (ert-deftest my-vterm-toggle-should-not-hide-vterm-shown-on-other-frame ()
   (my-vterm-toggle-test--with-stubs
-      (:current-frame-window nil :other-frame-window stub-window)
+      (:other-frame-window stub-window)
     (my-vterm-toggle)
     (should-not (memq 'hide calls))))
 
 (ert-deftest my-vterm-toggle-should-not-reshow-vterm-shown-on-other-frame ()
   (my-vterm-toggle-test--with-stubs
-      (:current-frame-window nil :other-frame-window stub-window)
+      (:other-frame-window stub-window)
     (my-vterm-toggle)
     (should-not (memq 'show calls))))
-
-(ert-deftest my-vterm-toggle-should-hide-vterm-shown-on-current-frame ()
-  (my-vterm-toggle-test--with-stubs
-      (:current-frame-window stub-window :other-frame-window nil)
-    (my-vterm-toggle)
-    (should (equal calls '(hide)))))
 
 (ert-deftest my-vterm-toggle-should-prefer-current-frame-window-over-other-frame ()
   (my-vterm-toggle-test--with-stubs
       (:current-frame-window stub-window :other-frame-window other-window)
     (my-vterm-toggle)
-    (should (equal calls '(hide)))))
+    (should (equal calls '((select-window . stub-window))))))
+
+;;; State 3: vterm not visible anywhere -> show.
 
 (ert-deftest my-vterm-toggle-should-show-when-vterm-not-visible-anywhere ()
   (my-vterm-toggle-test--with-stubs
-      (:current-frame-window nil :other-frame-window nil)
+      ()
     (my-vterm-toggle)
     (should (equal calls '(show)))))
 
-(ert-deftest my-vterm-toggle-should-show-from-claude-buffer-without-other-frame-vterm ()
+;;; claude-code-ide buffers are not togglable, so from a claude buffer
+;;; the dispatch behaves as if focus were on a normal buffer.
+
+(ert-deftest my-vterm-toggle-should-show-from-claude-buffer-without-visible-vterm ()
   (my-vterm-toggle-test--with-stubs
-      (:current-frame-window nil :other-frame-window nil :claude-buffer-p t)
+      ()
     (my-vterm-toggle)
     (should (equal calls '(show)))))
 
 (ert-deftest my-vterm-toggle-should-focus-other-frame-vterm-from-claude-buffer ()
   (my-vterm-toggle-test--with-stubs
-      (:current-frame-window nil :other-frame-window stub-window :claude-buffer-p t)
+      (:other-frame-window stub-window)
     (my-vterm-toggle)
     (should (equal calls
                    '((select-window . stub-window)
                      (focus-frame . stub-frame))))))
+
+;;; Helper: other-frame window lookup.
 
 (ert-deftest my-vterm-toggle-get-other-frame-window-should-skip-selected-frame ()
   (cl-letf (((symbol-function 'window-list-1)

--- a/tests/my-vterm-toggle-test.el
+++ b/tests/my-vterm-toggle-test.el
@@ -1,0 +1,149 @@
+;;; my-vterm-toggle-test.el --- Tests for my-vterm-toggle dispatch -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Regression tests for the C-c t vterm toggle dispatch.
+;;
+;; The bug: `my-vterm-toggle' only looked for a vterm window on the
+;; selected frame (`vterm-toggle--get-window' walks `window-list' of the
+;; selected frame).  When the vterm buffer was visible on ANOTHER frame,
+;; the dispatch fell through to `vterm-toggle-show', whose
+;; `pop-to-buffer' path could select the other frame's window without
+;; transferring input focus, and a follow-up toggle then deleted the
+;; vterm window instead of focusing it.
+;;
+;; The fix: when a vterm window is visible on another frame and no vterm
+;; window exists on the selected frame, move input focus to that frame
+;; and select the window instead of hiding or re-showing the buffer.
+;;
+;; The tests stub the vterm-toggle collaborators and frame primitives
+;; with `cl-letf' because batch Emacs cannot create multiple real
+;; frames.  Run with:
+;;
+;;   emacs -Q --batch --eval "(package-initialize)" \
+;;     -L lisp -l ert -l tests/my-vterm-toggle-test.el \
+;;     -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'my-vterm-toggle)
+
+;; The dispatch consults these vterm-toggle definitions at runtime.  Give
+;; the symbols a loud default so a test that forgets to stub one fails
+;; clearly, even when the vterm-toggle package is absent in batch runs.
+(defvar vterm-toggle-hide-method)
+(dolist (collaborator '(vterm-toggle-show
+                        vterm-toggle-hide
+                        vterm-toggle--get-window
+                        vterm-toggle-togglable-buffer-p))
+  (unless (fboundp collaborator)
+    (defalias collaborator
+      (lambda (&rest _)
+        (error "Unexpected call to %s" collaborator)))))
+
+(defmacro my-vterm-toggle-test--with-stubs (spec &rest body)
+  "Run BODY with the toggle collaborators stubbed according to SPEC.
+SPEC is a plist with keys :current-frame-window, :other-frame-window,
+and :claude-buffer-p.  BODY can inspect the recorded action symbols in
+the variable `calls' (in reverse order of invocation)."
+  (declare (indent 1))
+  `(let ((calls '())
+         (vterm-toggle-hide-method 'delete-window))
+     (cl-letf (((symbol-function 'vterm-toggle--get-window)
+                (lambda () ',(plist-get spec :current-frame-window)))
+               ((symbol-function 'my-vterm-toggle--get-other-frame-window)
+                (lambda () ',(plist-get spec :other-frame-window)))
+               ((symbol-function 'my-vterm-toggle-claude-code-ide-buffer-p)
+                (lambda (_buffer) ',(plist-get spec :claude-buffer-p)))
+               ((symbol-function 'vterm-toggle-show)
+                (lambda (&rest _) (push 'show calls)))
+               ((symbol-function 'vterm-toggle-hide)
+                (lambda (&rest _) (push 'hide calls)))
+               ((symbol-function 'window-frame)
+                (lambda (_window) 'stub-frame))
+               ((symbol-function 'select-frame-set-input-focus)
+                (lambda (frame) (push (cons 'focus-frame frame) calls)))
+               ((symbol-function 'select-window)
+                (lambda (window &optional _norecord)
+                  (push (cons 'select-window window) calls))))
+       (with-temp-buffer
+         ,@body))))
+
+(ert-deftest my-vterm-toggle-should-focus-frame-showing-vterm-on-other-frame ()
+  (my-vterm-toggle-test--with-stubs
+      (:current-frame-window nil :other-frame-window stub-window)
+    (my-vterm-toggle)
+    (should (equal calls
+                   '((select-window . stub-window)
+                     (focus-frame . stub-frame))))))
+
+(ert-deftest my-vterm-toggle-should-not-hide-vterm-shown-on-other-frame ()
+  (my-vterm-toggle-test--with-stubs
+      (:current-frame-window nil :other-frame-window stub-window)
+    (my-vterm-toggle)
+    (should-not (memq 'hide calls))))
+
+(ert-deftest my-vterm-toggle-should-not-reshow-vterm-shown-on-other-frame ()
+  (my-vterm-toggle-test--with-stubs
+      (:current-frame-window nil :other-frame-window stub-window)
+    (my-vterm-toggle)
+    (should-not (memq 'show calls))))
+
+(ert-deftest my-vterm-toggle-should-hide-vterm-shown-on-current-frame ()
+  (my-vterm-toggle-test--with-stubs
+      (:current-frame-window stub-window :other-frame-window nil)
+    (my-vterm-toggle)
+    (should (equal calls '(hide)))))
+
+(ert-deftest my-vterm-toggle-should-prefer-current-frame-window-over-other-frame ()
+  (my-vterm-toggle-test--with-stubs
+      (:current-frame-window stub-window :other-frame-window other-window)
+    (my-vterm-toggle)
+    (should (equal calls '(hide)))))
+
+(ert-deftest my-vterm-toggle-should-show-when-vterm-not-visible-anywhere ()
+  (my-vterm-toggle-test--with-stubs
+      (:current-frame-window nil :other-frame-window nil)
+    (my-vterm-toggle)
+    (should (equal calls '(show)))))
+
+(ert-deftest my-vterm-toggle-should-show-from-claude-buffer-without-other-frame-vterm ()
+  (my-vterm-toggle-test--with-stubs
+      (:current-frame-window nil :other-frame-window nil :claude-buffer-p t)
+    (my-vterm-toggle)
+    (should (equal calls '(show)))))
+
+(ert-deftest my-vterm-toggle-should-focus-other-frame-vterm-from-claude-buffer ()
+  (my-vterm-toggle-test--with-stubs
+      (:current-frame-window nil :other-frame-window stub-window :claude-buffer-p t)
+    (my-vterm-toggle)
+    (should (equal calls
+                   '((select-window . stub-window)
+                     (focus-frame . stub-frame))))))
+
+(ert-deftest my-vterm-toggle-get-other-frame-window-should-skip-selected-frame ()
+  (cl-letf (((symbol-function 'window-list-1)
+             (lambda (&rest _) '(window-on-selected-frame window-on-other-frame)))
+            ((symbol-function 'window-frame)
+             (lambda (window)
+               (if (eq window 'window-on-selected-frame) 'frame-a 'frame-b)))
+            ((symbol-function 'selected-frame) (lambda () 'frame-a))
+            ((symbol-function 'window-buffer) (lambda (_window) (current-buffer)))
+            ((symbol-function 'vterm-toggle-togglable-buffer-p)
+             (lambda (_buffer) t)))
+    (should (eq (my-vterm-toggle--get-other-frame-window)
+                'window-on-other-frame))))
+
+(ert-deftest my-vterm-toggle-get-other-frame-window-should-ignore-non-vterm-windows ()
+  (cl-letf (((symbol-function 'window-list-1)
+             (lambda (&rest _) '(window-on-other-frame)))
+            ((symbol-function 'window-frame) (lambda (_window) 'frame-b))
+            ((symbol-function 'selected-frame) (lambda () 'frame-a))
+            ((symbol-function 'window-buffer) (lambda (_window) (current-buffer)))
+            ((symbol-function 'vterm-toggle-togglable-buffer-p)
+             (lambda (_buffer) nil)))
+    (should-not (my-vterm-toggle--get-other-frame-window))))
+
+(provide 'my-vterm-toggle-test)
+;;; my-vterm-toggle-test.el ends here


### PR DESCRIPTION
## Problem: C-c t did not behave as a focus-aware toggle

The stock `vterm-toggle` dispatch (and the first iteration of this PR)
failed the expected toggle flow in three ways:

1. `vterm-toggle--get-window` only inspects the selected frame, so a
   vterm visible on another frame was never focused; the dispatch
   re-showed or deleted it instead.
2. Hiding a focused vterm that was the sole ordinary window of its
   frame signaled "Attempt to delete minibuffer or sole ordinary
   window". `vterm-toggle-hide` calls `delete-window` whenever
   `window-deletable-p` is non-nil, but that predicate returns the
   symbol `frame` for a sole window. This made C-c t appear dead right
   after the cross-frame focus jump.
3. A vterm visible on the selected frame was hidden even when focus
   was on another window, instead of receiving focus.

## Fix: a three-state dispatch in lisp/my-vterm-toggle.el

`my-vterm-toggle` now implements a state machine:

1. Focus is on a togglable vterm: hide it. When the vterm is the sole
   window of its frame, delete the frame instead of calling
   `vterm-toggle-hide` (avoids the `delete-window` error). On the last
   visible frame, fall back to `vterm-toggle-hide`, which buries the
   buffer.
2. The vterm is visible but focus is elsewhere: move focus to it. This
   covers both another window on the selected frame and a window on
   another visible frame (via `select-frame-set-input-focus`).
3. The vterm is not visible anywhere: show it.

claude-code-ide session buffers stay excluded through
`vterm-toggle-togglable-buffer-functions`, so the toggle never hides or
lands on them. Prefix arguments keep their stock meaning: a prefix
other than 1 inside a vterm spawns a new vterm; C-u C-u toggles
`vterm-toggle-fullscreen-p` for the show.

The dispatch and the claude-code-ide predicates live in
lisp/my-vterm-toggle.el so tests can load them without the whole init.

## CI

`.github/workflows/test.yml` enumerated test files explicitly and did
not include the vterm suite, so it never ran on GitHub Actions. The
workflow now globs `tests/*.el`, so this suite and any future test
file run without touching the workflow. The vterm suite passes without
the vterm-toggle package installed because it stubs every
collaborator.

## Verification

- tests/my-vterm-toggle-test.el: 15 ERT tests covering all three
  states, the sole-window frame deletion, the last-frame fallback, the
  claude-code-ide cases, and the prefix-argument behavior. All pass,
  both with the local package set and in a CI-like run without
  package-initialize.
- Scripted GUI Emacs reproduction (isolated `-Q` instance, two real
  frames): cross-frame focus jump, hide-when-focused on a sole-window
  frame (previously signaled an error), and same-frame unfocused focus
  move all behave as designed.
- `batch-byte-compile` on lisp/my-vterm-toggle.el with
  `byte-compile-error-on-warn`: no warnings.
- CI-style `emacs -batch -l init.el -f batch-byte-compile init.el`:
  passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

