### PR TITLE
Remove claude-code-ide integration

### DIFF
--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -1122,17 +1122,11 @@ Changes AFTER the selected commit are shown in the fringe (exclusive)."
 
 ;; Export EDITOR in terminal buffers so commands like `git commit' launched
 ;; inside the shell open their editor buffer in this Emacs (via emacsclient)
-;; instead of spawning a nested editor.  Skipped in claude-code-ide session
-;; buffers because Claude runs its own CLI there and does not need emacsclient.
-(defun my/with-editor-export-editor-maybe ()
-  (unless (and (fboundp 'claude-code-ide--session-buffer-p)
-               (claude-code-ide--session-buffer-p (current-buffer)))
-    (with-editor-export-editor)))
-
+;; instead of spawning a nested editor.
 (use-package with-editor
-  :hook ((shell-mode . my/with-editor-export-editor-maybe)
-         (eshell-mode . my/with-editor-export-editor-maybe)
-         (vterm-mode . my/with-editor-export-editor-maybe)))
+  :hook ((shell-mode . with-editor-export-editor)
+         (eshell-mode . with-editor-export-editor)
+         (vterm-mode . with-editor-export-editor)))
 
 (use-package yasnippet :ensure t
   :config
@@ -1270,14 +1264,10 @@ Changes AFTER the selected commit are shown in the fringe (exclusive)."
 (use-package vterm-toggle :ensure t
   :after (vterm)
   :config
-  ;; The toggle dispatch and the claude-code-ide predicates live in
-  ;; lisp/my-vterm-toggle.el so that tests/my-vterm-toggle-test.el can load
-  ;; them without pulling in the whole init.
+  ;; The toggle dispatch lives in lisp/my-vterm-toggle.el so that
+  ;; tests/my-vterm-toggle-test.el can load it without pulling in the whole
+  ;; init.
   (require 'my-vterm-toggle)
-  ;; Hide claude-code-ide session buffers from vterm-toggle so that pressing
-  ;; the toggle key never lands on them.
-  (add-to-list 'vterm-toggle-togglable-buffer-functions
-               #'my-vterm-toggle-non-claude-code-ide-buffer-p)
   :bind
   ("\C-c t" . 'my-vterm-toggle)
   ;; ("\C-c t" . 'vterm-toggle)
@@ -1448,20 +1438,6 @@ The source buffer is added as gptel context for full file awareness."
                         (window-width . 0.4)))))
 
   )
-
-;; Claude Code IDE integration.
-;; Runs the Claude Code CLI inside a vterm buffer and exposes Emacs
-;; functionality to Claude via the Model Context Protocol (MCP).
-;; Requires the `claude` CLI to be on PATH.
-(use-package claude-code-ide
-  :ensure nil
-  :vc (:url "https://github.com/manzaltu/claude-code-ide.el" :rev :newest)
-  :after vterm
-  :bind ("C-c C-a" . claude-code-ide-menu)
-  :custom
-  (claude-code-ide-terminal-backend 'vterm)
-  :config
-  (claude-code-ide-emacs-tools-setup))
 
 ;; agent-shell: chat with ACP-compatible coding agents (Claude, Gemini)
 ;; in a comint-based shell buffer. Talks to agents over the Agent Client

--- a/lisp/my-vterm-toggle.el
+++ b/lisp/my-vterm-toggle.el
@@ -1,16 +1,10 @@
-;;; my-vterm-toggle.el --- vterm toggle aware of claude-code-ide and frames -*- lexical-binding: t; -*-
+;;; my-vterm-toggle.el --- frame-aware vterm toggle -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 ;; A vterm-toggle dispatch that fixes shortcomings of the stock
 ;; `vterm-toggle' command for this setup:
 ;;
-;; 1. claude-code-ide sessions run inside vterm buffers, so the stock
-;;    toggle happily lands on (or hides) a Claude session.  The
-;;    predicates here identify those buffers; init-prog.el registers
-;;    them in `vterm-toggle-togglable-buffer-functions' so vterm-toggle
-;;    skips them everywhere.
-;;
-;; 2. The stock dispatch hides the vterm whenever a vterm window is
+;; 1. The stock dispatch hides the vterm whenever a vterm window is
 ;;    visible on the selected frame, even when focus is on another
 ;;    window, and it never looks at other frames at all.  The dispatch
 ;;    here implements a three-state machine instead:
@@ -19,7 +13,7 @@
 ;;      move input focus to it
 ;;    - vterm not visible: show it
 ;;
-;; 3. `vterm-toggle-hide' with the `delete-window' hide method calls
+;; 2. `vterm-toggle-hide' with the `delete-window' hide method calls
 ;;    `delete-window' whenever `window-deletable-p' is non-nil, but that
 ;;    predicate returns the symbol `frame' for a frame's sole ordinary
 ;;    window, and `delete-window' then signals "Attempt to delete
@@ -35,28 +29,9 @@
 (declare-function vterm-toggle-hide "vterm-toggle")
 (declare-function vterm-toggle--get-window "vterm-toggle")
 (declare-function vterm-toggle-togglable-buffer-p "vterm-toggle")
-(declare-function claude-code-ide--session-buffer-p "claude-code-ide")
 
 (defvar vterm-buffer-name)
 (defvar vterm-toggle-fullscreen-p)
-(defvar claude-code-ide--processes)
-
-(defun my-vterm-toggle-claude-code-ide-buffer-p (buffer)
-  "Return non-nil when BUFFER hosts a claude-code-ide session.
-The session-buffer-p check fails for vterm buffers that have been
-renamed via `vterm-buffer-name-string', so also consult
-`claude-code-ide--processes' to identify them by process-buffer."
-  (or (and (fboundp 'claude-code-ide--session-buffer-p)
-           (claude-code-ide--session-buffer-p buffer))
-      (and (boundp 'claude-code-ide--processes)
-           (cl-loop for proc being the hash-values of claude-code-ide--processes
-                    when (and (process-live-p proc)
-                              (eq (process-buffer proc) buffer))
-                    return t))))
-
-(defun my-vterm-toggle-non-claude-code-ide-buffer-p (buffer)
-  "Return non-nil when BUFFER is not a claude-code-ide session buffer."
-  (not (my-vterm-toggle-claude-code-ide-buffer-p buffer)))
 
 (defun my-vterm-toggle--get-other-frame-window ()
   "Return a window on another visible frame showing a togglable vterm."
@@ -80,10 +55,9 @@ On the last visible frame `window-deletable-p' returns nil and
   "Toggle the vterm as a three-state dispatch.
 Hide the vterm when focus is already on it, move focus to a visible
 vterm window (on this or another frame) otherwise, and show the vterm
-when it is not visible anywhere.  claude-code-ide session buffers are
-not togglable, so the toggle never hides or lands on them.  With
-prefix argument ARGS other than 1 inside a vterm, spawn a new vterm;
-with prefix argument 4 while no vterm is visible, toggle
+when it is not visible anywhere.  With prefix argument ARGS other than
+1 inside a vterm, spawn a new vterm; with prefix argument 4 while no
+vterm is visible, toggle
 `vterm-toggle-fullscreen-p' for this show."
   (interactive "P")
   (let* ((focused-on-vterm (vterm-toggle-togglable-buffer-p (current-buffer)))

--- a/tests/my-vterm-toggle-test.el
+++ b/tests/my-vterm-toggle-test.el
@@ -162,23 +162,6 @@ BODY can inspect the recorded action symbols in the variable `calls'
     (my-vterm-toggle)
     (should (equal calls '(show)))))
 
-;;; claude-code-ide buffers are not togglable, so from a claude buffer
-;;; the dispatch behaves as if focus were on a normal buffer.
-
-(ert-deftest my-vterm-toggle-should-show-from-claude-buffer-without-visible-vterm ()
-  (my-vterm-toggle-test--with-stubs
-      ()
-    (my-vterm-toggle)
-    (should (equal calls '(show)))))
-
-(ert-deftest my-vterm-toggle-should-focus-other-frame-vterm-from-claude-buffer ()
-  (my-vterm-toggle-test--with-stubs
-      (:other-frame-window stub-window)
-    (my-vterm-toggle)
-    (should (equal calls
-                   '((select-window . stub-window)
-                     (focus-frame . stub-frame))))))
-
 ;;; Helper: other-frame window lookup.
 
 (ert-deftest my-vterm-toggle-get-other-frame-window-should-skip-selected-frame ()


### PR DESCRIPTION
This PR removes all integration with the claude-code-ide package, simplifying the codebase by eliminating special handling for Claude Code IDE session buffers.

## Summary
The claude-code-ide package and all related configuration have been removed from the project. This includes the package definition, helper functions, and special buffer handling logic that was previously needed to prevent Claude session buffers from interfering with vterm-toggle behavior.

## Key Changes

- **Removed claude-code-ide package configuration** from `init-prog.el`:
  - Deleted the entire `use-package claude-code-ide` block
  - Removed the `claude-code-ide-emacs-tools-setup` initialization

- **Simplified with-editor setup** in `init-prog.el`:
  - Removed the `my/with-editor-export-editor-maybe` wrapper function that checked for Claude session buffers
  - Directly hooked `with-editor-export-editor` to shell modes instead

- **Cleaned up vterm-toggle configuration** in `init-prog.el`:
  - Removed the registration of `my-vterm-toggle-non-claude-code-ide-buffer-p` in `vterm-toggle-togglable-buffer-functions`
  - Updated comments to remove references to Claude session buffer handling

- **Refactored my-vterm-toggle.el**:
  - Removed `my-vterm-toggle-claude-code-ide-buffer-p` and `my-vterm-toggle-non-claude-code-ide-buffer-p` helper functions
  - Removed declarations for claude-code-ide functions and variables
  - Updated module docstring and comments to remove Claude-specific documentation
  - Simplified the `my-vterm-toggle` docstring

- **Removed related tests** from `tests/my-vterm-toggle-test.el`:
  - Deleted test cases for Claude buffer behavior: `my-vterm-toggle-should-show-from-claude-buffer-without-visible-vterm` and `my-vterm-toggle-should-focus-other-frame-vterm-from-claude-buffer`

## Impact
The vterm-toggle dispatch now operates without special cases for Claude session buffers, resulting in simpler and more maintainable code. The three-state toggle behavior for frame-aware vterm management is preserved.

https://claude.ai/code/session_017YdaAeUEHWvL5fuwo2MyUs