### PR TITLE
Add cov for code coverage display

### DIFF
--- a/init.el
+++ b/init.el
@@ -68,7 +68,7 @@
  '(package-selected-packages
    '(aidermacs all-the-icons anzu auth-source-1password auto-highlight-symbol backup-each-save
                base16-theme blamer bm browse-at-remote buffer-move buttercup calfw cape casual
-               clang-format cmake-mode coffee-mode corfu diff-hl docker dockerfile-mode elpy
+               clang-format cmake-mode coffee-mode corfu cov diff-hl docker dockerfile-mode elpy
                embark-consult euslisp-mode expreg fill-column-indicator flycheck forge gcmh gist
                git-auto-commit-mode go-mode google-c-style google-this gptel graphviz-dot-mode hiwin
                hyde imenus jinja2-mode jinx json-mode lsp-sourcekit lsp-ui lua-mode marginalia

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -569,6 +569,25 @@
   (flycheck-add-next-checker 'python-flake8 'python-pylint)
   )
 
+;; Display code coverage in the left fringe. `cov' locates the coverage file by
+;; itself: gcov (C/C++), lcov tracefiles (Go/Rust/JS/Ruby via converters),
+;; coverage.json (coverage.py), clover.xml and coveralls output are all
+;; supported. Generating those files is left to each project; enable `cov-mode'
+;; in a buffer to look at the result.
+(use-package cov
+  :ensure t
+  :defer t
+  :commands (cov-mode cov-update cov-visit-coverage-file)
+  :init
+  ;; Mark lines as executed/not-executed instead of drawing an execution-count
+  ;; heat map.
+  (setq cov-coverage-mode t)
+  :config
+  ;; `cov-lcov-patterns' only looks for "*.info" by default. Add the places
+  ;; where tracefiles usually end up.
+  (setq cov-lcov-patterns '("*.info" "coverage/lcov.info" "lcov.info"))
+  )
+
 (use-package minuet
   :ensure t
   :bind


### PR DESCRIPTION
Show code coverage in the left fringe via the `cov' package from MELPA.
It locates the coverage file on its own and understands gcov (C/C++),
lcov tracefiles (Go/Rust/JS/Ruby via converters), coverage.json from
coverage.py, clover.xml and coveralls output, so a single package covers
every language configured here.

`cov-mode' is left as an on-demand buffer-local minor mode rather than
being enabled globally, and generating the coverage files themselves
stays the responsibility of each project.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013ta1sXEW3rLEhtHMv8cH1J