### PR TITLE
Add avy package for fast text navigation

### DIFF
--- a/lisp/init-editor.el
+++ b/lisp/init-editor.el
@@ -264,6 +264,16 @@ if ENV-SH indicates a remote path. Relies on the helper function
    )
   )
 
+;;; Jump to visible text
+
+(use-package avy
+  :ensure t
+  :bind (("C-c j" . 'avy-goto-char-timer)
+         ("C-c J" . 'avy-goto-line))
+  :custom
+  ;; Shorter than the 0.5s default so candidates appear while still typing.
+  (avy-timeout-seconds 0.3))
+
 ;;; Region expansion
 
 (use-package expreg


### PR DESCRIPTION
## Summary
Added the `avy` package to enable fast navigation to visible text in the buffer using keyboard shortcuts.

## Changes
- Installed and configured the `avy` package with `use-package`
- Bound `C-c j` to `avy-goto-char-timer` for jumping to characters
- Bound `C-c J` to `avy-goto-line` for jumping to lines
- Configured `avy-timeout-seconds` to 0.3 seconds (reduced from default 0.5s) to display candidates more responsively while typing

## Implementation Details
The timeout reduction from 0.5s to 0.3s allows avy candidates to appear faster during typing, improving the interactive experience without sacrificing usability.

https://claude.ai/code/session_018PmFwkXH5DbNoLoFoMfQdb