### PR TITLE
Inherit checkbox when continuing an org list with M-RET

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -86,6 +86,23 @@
 
   (add-hook 'org-todo-state-hook #'my-org-schedule-if-todo)
   (add-hook 'org-after-todo-state-change-hook #'my-org-schedule-if-todo)
+
+  (defun my-org-continue-checkbox-item ()
+    "Continue a checkbox list with a new unchecked checkbox item.
+Intended for `org-metareturn-hook'.  When point is in a list item that
+already has a checkbox, `org-meta-return' (M-RET) otherwise inserts a
+new item without one.  Insert a new item with an empty \"[ ]\" checkbox
+instead and return non-nil so `org-meta-return' stops.  Return nil when
+point is not in a checkbox item, so the normal dispatch proceeds."
+    (let ((item-start (and (not current-prefix-arg) (org-in-item-p))))
+      (when (and item-start
+                 (save-excursion
+                   (goto-char item-start)
+                   (org-at-item-checkbox-p)))
+        (org-insert-item t)
+        t)))
+
+  (add-hook 'org-metareturn-hook #'my-org-continue-checkbox-item)
   ;; org-babel
   (org-babel-do-load-languages 'org-babel-load-languages
                                '((plantuml . t)


### PR DESCRIPTION
## Summary

In an org-mode list, `M-RET` (`org-meta-return`) continues the list by inserting a new item. When the current item is a checkbox item (`- [ ] foo`), the new item lost the checkbox and became a plain `- ` item.

`org-meta-return` calls `org-insert-item` with no checkbox argument, so `org-list-insert-item` builds the bullet with `(box (and checkbox "[ ]"))` = nil and omits the `[ ]`.

This adds `my-org-continue-checkbox-item` to `org-metareturn-hook`. When point is in a list item that already has a checkbox, it inserts the new item with an empty `[ ]` checkbox instead.

## Behavior

- `- [ ] first` + M-RET -> new item `- [ ] ` (inherits an unchecked checkbox).
- `- [X] done` + M-RET -> new item `- [ ] ` (a new item is always unchecked).
- `- first` (no checkbox) -> new item `- ` (unchanged).
- `1. [ ] one` + M-RET -> new item `2. [ ] ` (numbered lists inherit too).
- Description lists, tables, and prefix-arg heading insertion are untouched (the hook returns nil and the normal `org-meta-return` dispatch proceeds).

## Testing

- Isolated byte-compile of the new function: no warnings.
- CI-equivalent byte-compile of `init.el`: exit 0, no new warnings.
- Batch runs of `org-meta-return` confirm every case above.
- Manual check in a live Emacs: confirmed by the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)