### PR TITLE
Add apheleia for format-on-save

### DIFF
--- a/init.el
+++ b/init.el
@@ -66,7 +66,7 @@
  ;; If there is more than one, they won't work right.
  '(minuet-auto-suggestion-block-predicates '(minuet-evil-not-insert-state-p my-not-eolp) nil nil "Customized with use-package minuet")
  '(package-selected-packages
-   '(aidermacs all-the-icons anzu auth-source-1password auto-highlight-symbol backup-each-save
+   '(aidermacs all-the-icons anzu apheleia auth-source-1password auto-highlight-symbol backup-each-save
                base16-theme blamer bm browse-at-remote buffer-move buttercup calfw cape casual
                clang-format cmake-mode coffee-mode corfu diff-hl docker dockerfile-mode elpy
                embark-consult euslisp-mode expreg fill-column-indicator flycheck forge gcmh gist
@@ -75,13 +75,12 @@
                minuet modern-cpp-font-lock multi-vterm multiple-cursors nix-mode nlinum ob-mermaid
                orderless org-ai org-download org-excalidraw org-faces org-modern org-roam outshine
                persistent-scratch php-mode powerline projectile protobuf-mode puppet-mode py-yapf
-               qml-mode
-               rainbow-delimiters recentf-ext rust-mode slack smart-cursor-color smart-mode-line
-               smartrep solarized-theme sqlite3 sr-speedbar string-inflection swift-mode swiper
-               switch-buffer-functions switch-window sx systemd terraform-mode thingopt total-lines
-               transpose-frame treemacs-magit treesit-auto trr tsx-mode typescript-mode udev-mode
-               undo-tree vertico-posframe volatile-highlights vterm-toggle vundo window-purpose
-               yaml-mode yasnippet-capf yatemplate))
+               qml-mode rainbow-delimiters recentf-ext rust-mode slack smart-cursor-color
+               smart-mode-line smartrep solarized-theme sqlite3 sr-speedbar string-inflection
+               swift-mode swiper switch-buffer-functions switch-window sx systemd terraform-mode
+               thingopt total-lines transpose-frame treemacs-magit treesit-auto trr tsx-mode
+               typescript-mode udev-mode undo-tree vertico-posframe volatile-highlights vterm-toggle
+               vundo window-purpose yaml-mode yasnippet-capf yatemplate))
  '(package-vc-selected-packages
    '((org-excalidraw :url "https://github.com/4honor/org-excalidraw.git"))))
 (custom-set-faces

--- a/lisp/garaemon-objective-c.el
+++ b/lisp/garaemon-objective-c.el
@@ -54,7 +54,7 @@
               (define-key objc-mode-map "\C-cc"    'uncomment-region)
               (setq compile-command
                     "xcodebuild -project ../*.xcodeproj -configuration Debug -sdk iphonesimulator5.0 ")
-                    ;;"xcodebuild -project ../*.xcodeproj -configuration Debug -sdk iphonesimulator4.3 ")
+              ;;"xcodebuild -project ../*.xcodeproj -configuration Debug -sdk iphonesimulator4.3 ")
               (setq compilation-scroll-output t)))
 
 (defun doc ()

--- a/lisp/init-editor.el
+++ b/lisp/init-editor.el
@@ -235,8 +235,8 @@ if ENV-SH indicates a remote path. Relies on the helper function
   (embark-prompter #'embark-completing-read-prompter)
   ;; Do not show *Embark Actions*
   (embark-indicators '(embark-minimal-indicator
-                            embark-highlight-indicator
-                            embark-isearch-highlight-indicator))
+                       embark-highlight-indicator
+                       embark-isearch-highlight-indicator))
   :bind (("C-." . embark-act)
          :map minibuffer-local-map
          ("C-c C-c" . embark-collect)

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -14,8 +14,8 @@
   :requires (cl-lib)
   :init
   (setq org-jouornelly-file
-   (expand-file-name
-    "~/Library/Mobile Documents/iCloud~com~xenodium~Journelly/Documents/Journelly.org"))
+        (expand-file-name
+         "~/Library/Mobile Documents/iCloud~com~xenodium~Journelly/Documents/Journelly.org"))
   ;; Only set the default when custom.el has not already provided one, so
   ;; per-machine overrides via custom.el take precedence.
   (unless (boundp 'org-directory)
@@ -101,9 +101,9 @@
   (plist-put org-format-latex-options :foreground "whitesmoke")
   ;; The default font is too small. Increase the size.
   (plist-put org-format-latex-options :scale 2.0)
-;; Customize `textwidth` in LaTeX headers from -3cm to -6cm.
-;; This adjustment moves equation numbers further left, compensating for increased font size
-;; and ensuring proper alignment, as `org-format-latex-header` updates.
+  ;; Customize `textwidth` in LaTeX headers from -3cm to -6cm.
+  ;; This adjustment moves equation numbers further left, compensating for increased font size
+  ;; and ensuring proper alignment, as `org-format-latex-header` updates.
   (setq org-format-latex-header
         "\\documentclass{article}
 \\usepackage[usenames]{color}
@@ -284,7 +284,7 @@ Date format is YYYY-MM-DD.")
                        (when (and buffer-file-name
                                   (string-prefix-p org-directory
                                                    (file-name-directory buffer-file-name)))
-                       )))
+                         )))
          (org-agenda-mode . (lambda ()
                               (display-line-numbers-mode -1)
                               (display-fill-column-indicator-mode -1)))
@@ -299,15 +299,15 @@ Date format is YYYY-MM-DD.")
 
   (defmacro define-org-quick-command (new-func org-func &optional kill-new-buffers)
     `(defun ,new-func ()
-      ,(format "Call %s with Org features tuned for speed.
+       ,(format "Call %s with Org features tuned for speed.
 
 Always disables: global watchers (auto-revert, jinx, treesit-auto,
 magit refresh, vc), Org startup actions (inline images, indent,
 LaTeX preview, folding), persistent element-cache I/O, and bumps
 the GC threshold.%s"
-               org-func
-               (if kill-new-buffers
-                   "
+                org-func
+                (if kill-new-buffers
+                    "
 
 Also disables per-file setup hooks (`org-mode-hook',
 `after-change-major-mode-hook', `find-file-hook') and dir-locals
@@ -315,7 +315,7 @@ lookup for additional speed. Org buffers opened during this
 command (and not already visited beforehand) are killed afterwards
 so they get a fresh, fully configured setup the next time they are
 visited."
-                 "
+                  "
 
 Per-file setup hooks (`org-mode-hook',
 `after-change-major-mode-hook', `find-file-hook') are left active
@@ -323,56 +323,56 @@ because the caller (e.g. `org-agenda') stores markers into the
 buffers it opens, and the user will dereference them later (e.g.
 by clicking an agenda entry). Those buffers therefore need to be
 fully configured, not stripped down."))
-      (interactive)
-      (let ((started-at (float-time))
-            ,@(when kill-new-buffers
-                '((pre-existing-buffers (buffer-list))))
-            (auto-revert-was-on global-auto-revert-mode)
-            (jinx-was-on (and (boundp 'global-jinx-mode) global-jinx-mode))
-            (treesit-was-on (and (boundp 'global-treesit-auto-mode)
-                                 global-treesit-auto-mode))
-            (gc-cons-threshold (* 500 1024 1024))
-            (org-modules nil)
-            ,@(when kill-new-buffers
-                ;; These bindings strip a freshly opened buffer down to a
-                ;; bare org-mode shell. Safe only when we throw the buffer
-                ;; away afterwards; otherwise the user inherits a broken,
-                ;; feature-less buffer.
-                '((org-mode-hook nil)
-                  (after-change-major-mode-hook nil)
-                  (find-file-hook nil)
-                  (enable-dir-local-variables nil)))
-            (org-element-cache-persistent nil)
-            (org-inhibit-startup t)
-            (org-startup-with-inline-images nil)
-            (org-startup-indented nil)
-            (org-startup-with-latex-preview nil)
-            (org-startup-folded 'showall)
-            (org-agenda-inhibit-startup t)
-            (magit-refresh-status-buffer nil)
-            (magit-auto-revert-mode nil)
-            (vc-handled-backends nil)
-            (treesit-auto-langs nil))
-        (when auto-revert-was-on (global-auto-revert-mode -1))
-        (when jinx-was-on (global-jinx-mode -1))
-        (when treesit-was-on (global-treesit-auto-mode -1))
-        (unwind-protect
-            (call-interactively ',org-func)
-          ,@(when kill-new-buffers
-              '((dolist (buf (buffer-list))
-                  (when (and (not (memq buf pre-existing-buffers))
-                             (buffer-live-p buf)
-                             (buffer-file-name buf)
-                             (not (buffer-modified-p buf))
-                             (with-current-buffer buf
-                               (derived-mode-p 'org-mode)))
-                    (kill-buffer buf)))))
-          (when auto-revert-was-on (global-auto-revert-mode 1))
-          (when jinx-was-on (global-jinx-mode 1))
-          (when treesit-was-on (global-treesit-auto-mode 1)))
-        (let* ((ended-at (float-time))
-               (delta-duration (- ended-at started-at)))
-          (message "%s took %s sec" (symbol-name ',org-func) delta-duration)))))
+       (interactive)
+       (let ((started-at (float-time))
+             ,@(when kill-new-buffers
+                 '((pre-existing-buffers (buffer-list))))
+             (auto-revert-was-on global-auto-revert-mode)
+             (jinx-was-on (and (boundp 'global-jinx-mode) global-jinx-mode))
+             (treesit-was-on (and (boundp 'global-treesit-auto-mode)
+                                  global-treesit-auto-mode))
+             (gc-cons-threshold (* 500 1024 1024))
+             (org-modules nil)
+             ,@(when kill-new-buffers
+                 ;; These bindings strip a freshly opened buffer down to a
+                 ;; bare org-mode shell. Safe only when we throw the buffer
+                 ;; away afterwards; otherwise the user inherits a broken,
+                 ;; feature-less buffer.
+                 '((org-mode-hook nil)
+                   (after-change-major-mode-hook nil)
+                   (find-file-hook nil)
+                   (enable-dir-local-variables nil)))
+             (org-element-cache-persistent nil)
+             (org-inhibit-startup t)
+             (org-startup-with-inline-images nil)
+             (org-startup-indented nil)
+             (org-startup-with-latex-preview nil)
+             (org-startup-folded 'showall)
+             (org-agenda-inhibit-startup t)
+             (magit-refresh-status-buffer nil)
+             (magit-auto-revert-mode nil)
+             (vc-handled-backends nil)
+             (treesit-auto-langs nil))
+         (when auto-revert-was-on (global-auto-revert-mode -1))
+         (when jinx-was-on (global-jinx-mode -1))
+         (when treesit-was-on (global-treesit-auto-mode -1))
+         (unwind-protect
+             (call-interactively ',org-func)
+           ,@(when kill-new-buffers
+               '((dolist (buf (buffer-list))
+                   (when (and (not (memq buf pre-existing-buffers))
+                              (buffer-live-p buf)
+                              (buffer-file-name buf)
+                              (not (buffer-modified-p buf))
+                              (with-current-buffer buf
+                                (derived-mode-p 'org-mode)))
+                     (kill-buffer buf)))))
+           (when auto-revert-was-on (global-auto-revert-mode 1))
+           (when jinx-was-on (global-jinx-mode 1))
+           (when treesit-was-on (global-treesit-auto-mode 1)))
+         (let* ((ended-at (float-time))
+                (delta-duration (- ended-at started-at)))
+           (message "%s took %s sec" (symbol-name ',org-func) delta-duration)))))
 
   (define-org-quick-command org-agenda-quick org-agenda)
   (define-org-quick-command org-set-tags-command-quick org-set-tags-command t)
@@ -624,10 +624,10 @@ Skip when the cached SVG is already newer than FILE."
   (org-roam-index-file (concat org-roam-directory "Index.org"))
   (org-roam-capture-templates
    '(("d" "default" plain "%?"
-     :target (file+head "%<%Y%m%d%H%M%S>-${slug}.org"
-                        "#+title: ${title}\n#+date: %T\n#+filetags: \n")
-     :unnarrowed t
-     :jump-to-captured t)))
+      :target (file+head "%<%Y%m%d%H%M%S>-${slug}.org"
+                         "#+title: ${title}\n#+date: %T\n#+filetags: \n")
+      :unnarrowed t
+      :jump-to-captured t)))
   :config
   (if (not (file-exists-p org-roam-directory))
       (make-directory org-roam-directory t))

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -1179,12 +1179,43 @@ Changes AFTER the selected commit are shown in the fringe (exclusive)."
 ;; result as a diff, so point and window scroll position never jump.
 ;; `:demand' is required because `:bind' alone would defer loading until the
 ;; first `C-c f', leaving `apheleia-global-mode' off until then.
+;;
+;; `apheleia-mode-alist' maps about 100 major modes to a formatter out of the
+;; box. The entries this configuration is likely to hit, `-ts-mode' variants
+;; included:
+;;
+;;   emacs-lisp, lisp                     lisp-indent (indent-region, built-in)
+;;   c, c++, objc                         clang-format
+;;   python                               ruff (set below; the default is black)
+;;   go                                   gofmt
+;;   rust                                 rustfmt
+;;   bash                                 shfmt
+;;   js, ts, tsx, json, yaml, css, html   prettier
+;;   ruby                                 prettier
+;;   lua                                  stylua
+;;   cmake                                cmake-format
+;;   terraform                            tofu fmt
+;;   toml                                 taplo
+;;   dockerfile                           dprint
+;;   nix                                  nixfmt
+;;   java                                 google-java-format
+;;   php                                  phpcs
+;;   latex                                latexindent
+;;   sql                                  pg_format
+;;
+;; Only lisp-indent runs in-process. Every other entry shells out, and apheleia
+;; skips the buffer silently when `executable-find' cannot locate the command.
+;; An uninstalled formatter therefore costs nothing beyond leaving the buffer
+;; unformatted. prettier is looked up in the project's node_modules before PATH,
+;; so TypeScript and the other prettier-backed modes only get formatted inside a
+;; project that carries prettier itself. Run `M-x describe-variable RET
+;; apheleia-mode-alist' for the full table.
 (use-package apheleia :ensure t
   :demand t
   :bind (("C-c f" . 'apheleia-format-buffer))
   :config
   ;; Format Python with ruff. The apheleia default is black, which is not
-  ;; installed, and a missing formatter makes every save pop up an error buffer.
+  ;; installed here, so Python buffers would otherwise stay unformatted.
   (setf (alist-get 'python-mode apheleia-mode-alist) 'ruff)
   (setf (alist-get 'python-ts-mode apheleia-mode-alist) 'ruff)
   (apheleia-global-mode +1)

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -1183,6 +1183,10 @@ Changes AFTER the selected commit are shown in the fringe (exclusive)."
   :demand t
   :bind (("C-c f" . 'apheleia-format-buffer))
   :config
+  ;; Format Python with ruff. The apheleia default is black, which is not
+  ;; installed, and a missing formatter makes every save pop up an error buffer.
+  (setf (alist-get 'python-mode apheleia-mode-alist) 'ruff)
+  (setf (alist-get 'python-ts-mode apheleia-mode-alist) 'ruff)
   (apheleia-global-mode +1)
   )
 

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -168,8 +168,8 @@
   ;; C-x p to switch buffer with inverse manner.
   ;; I have to define the keybind after removing the keybind of "C-x p" of project mode.
   (global-set-key "\C-xp" (lambda ()
-                          (interactive)
-                          (other-window -1)))
+                            (interactive)
+                            (other-window -1)))
 
   )
 
@@ -212,7 +212,7 @@
               ("\C-c <right>" . 'python-indent-shift-right)
               ("\C-c <left>" . 'python-indent-shift-left)
               ("\C-c\C-r" . 'projectile-run-task)
-         :map python-ts-mode-map
+              :map python-ts-mode-map
               ("\C-x\C-E" . 'python-shell-send-region-or-statement)
               ("\C-cE" . 'run-python-and-switch-to-shell)
               ("\C-ce" . 'run-python-and-switch-to-shell)
@@ -567,13 +567,13 @@
   :ensure t
   :bind
   (:map minuet-active-mode-map
-   ("TAB" . #'minuet-accept-suggestion) ;; accept whole completion
-   ("<M-return>" . #'minuet-accept-suggestion) ;; accept whole completion
-   ("M-A" . #'minuet-accept-suggestion) ;; accept whole completion
-   ;; Accept the first line of completion, or N lines with a numeric-prefix:
-   ;; e.g. C-u 2 M-a will accepts 2 lines of completion.
-   ("M-a" . #'minuet-accept-suggestion-line)
-   ("M-e" . #'minuet-dismiss-suggestion))
+        ("TAB" . #'minuet-accept-suggestion) ;; accept whole completion
+        ("<M-return>" . #'minuet-accept-suggestion) ;; accept whole completion
+        ("M-A" . #'minuet-accept-suggestion) ;; accept whole completion
+        ;; Accept the first line of completion, or N lines with a numeric-prefix:
+        ;; e.g. C-u 2 M-a will accepts 2 lines of completion.
+        ("M-a" . #'minuet-accept-suggestion-line)
+        ("M-e" . #'minuet-dismiss-suggestion))
   :hook (prog-mode . minuet-auto-suggestion-mode)
   :custom
   (minuet-provider 'openai-fim-compatible)
@@ -771,9 +771,9 @@ commit buffer being set up."
   :custom
   (gptel-magit-model 'gemma3:4b)
   (gptel-magit-backend (gptel-make-ollama "Ollama (gemmma3:4b)"
-    :host "localhost:11434"
-    :stream t
-    :models '(gemma3:4b)))
+                         :host "localhost:11434"
+                         :stream t
+                         :models '(gemma3:4b)))
   (gptel-magit-commit-prompt
    "You are a programmer. Based on the Git diff provided below, generate a concise and clear English commit message.
 You reply the commit message only.
@@ -836,15 +836,15 @@ Only truncate the title line to `git-commit-summary-max-length'."
 Invokes CALLBACK with the generated message when done."
     (let ((diff (magit-git-output "diff" "--cached")))
       (gptel-magit--request diff
-        :system gptel-magit-commit-prompt
-        :context nil
-        :callback (lambda (response info)
-                    (if (not (stringp response))
-                        (let ((status (plist-get info :status)))
-                          (message "gptel-magit: Failed to generate commit message. \
+                            :system gptel-magit-commit-prompt
+                            :context nil
+                            :callback (lambda (response info)
+                                        (if (not (stringp response))
+                                            (let ((status (plist-get info :status)))
+                                              (message "gptel-magit: Failed to generate commit message. \
 Is Ollama running? (ollama serve) Status: %s" status))
-                      (let ((msg (gptel-magit--format-commit-message response)))
-                        (funcall callback msg)))))))
+                                          (let ((msg (gptel-magit--format-commit-message response)))
+                                            (funcall callback msg)))))))
   :hook (magit-mode . gptel-magit-install))
 
 (use-package forge
@@ -984,9 +984,9 @@ collect inline comments via `my-forge-ediff-review-add-comment'."
            (pullreq (or (forge-get-pullreq :branch branch)
                         (let* ((repo (forge-get-repository :tracked))
                                (rows (forge-sql [:select [number]
-                                                 :from pullreq
-                                                 :where (and (= repository $s1)
-                                                             (= head-ref $s2))]
+                                                         :from pullreq
+                                                         :where (and (= repository $s1)
+                                                                     (= head-ref $s2))]
                                                 (oref repo id)
                                                 branch)))
                           (when rows
@@ -1235,7 +1235,7 @@ Changes AFTER the selected commit are shown in the fringe (exclusive)."
   (vterm-buffer-name-string  "*vterm: %s*")
   ;; Remove C-h from the original vterm-keymap-exceptions
   (vterm-keymap-exceptions '("C-c" "C-x" "C-u" "C-g" "C-l" "M-x" "M-o" "C-v" "M-v" "C-y" "M-y"
-                                  "C-k"))
+                             "C-k"))
   (vterm-always-compile-module t)
   :config
 
@@ -1335,7 +1335,7 @@ You have to follow the following orders:
       (if gptel-buffer
           (switch-to-buffer gptel-buffer)
         (call-interactively 'gptel)
-      )))
+        )))
 
   (defun my-gptel-archive-and-reset ()
     "Archives the current gptel buffer to ~/.gptel/sessions/ and clears/resets its content."

--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -501,11 +501,6 @@
   ;; direct-async process.
   (add-to-list 'lsp-disabled-clients 'yamlls-tramp)
   (add-to-list 'lsp-disabled-clients 'sh-tramp)
-  (defun my-lsp-format (s e)
-    (interactive "r")
-    (if (region-active-p)
-        (lsp-format-region s e)
-      (lsp-format-buffer)))
   (if (not (display-graphic-p))
       ;; header-line for LSP mode is hard to see in emacs -nw environment.
       ;; https://emacs.stackexchange.com/questions/77279/how-can-i-find-the-face-of-the-items-in-the-headeline-in-lsp-mode
@@ -541,7 +536,6 @@
   (lsp-pylsp-server-command '("uv" "tool" "run" "--from" "python-lsp-server" "pylsp" "--verbose"
                               "--log-file" "pylsp.log"))
   :bind (
-         ("C-c f" . 'my-lsp-format)
          ("M-." . 'lsp-find-definition)
          )
   )
@@ -1179,6 +1173,17 @@ Changes AFTER the selected commit are shown in the fringe (exclusive)."
 
   (add-hook 'compilation-filter-hook
             #'endless/colorize-compilation)
+  )
+
+;; apheleia runs an external formatter asynchronously on save. It applies the
+;; result as a diff, so point and window scroll position never jump.
+;; `:demand' is required because `:bind' alone would defer loading until the
+;; first `C-c f', leaving `apheleia-global-mode' off until then.
+(use-package apheleia :ensure t
+  :demand t
+  :bind (("C-c f" . 'apheleia-format-buffer))
+  :config
+  (apheleia-global-mode +1)
   )
 
 (use-package clang-format :ensure t

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -218,19 +218,19 @@ it from being deleted by `delete-other-windows` (C-x 1)."
   :custom
   ;; Highlight edited regions when emacs modifies buffers by regions
   (pulsar-pulse-region-functions
-    '(yank
-      yank-pop
-      append-next-kill
-      undo
-      undo-redo
-      backward-kill-word
-      kill-word
-      ;; vundo
-      vundo-backward
-      vundo-forward
-      vundo-step-back
-      vundo-step-forward
-      ))
+   '(yank
+     yank-pop
+     append-next-kill
+     undo
+     undo-redo
+     backward-kill-word
+     kill-word
+     ;; vundo
+     vundo-backward
+     vundo-forward
+     vundo-step-back
+     vundo-step-forward
+     ))
   :config
   ;; Pulsar runs `pulsar-resolve-function-aliases' every time
   ;; `pulsar-mode' is enabled in a new buffer, and each invocation walks

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -240,16 +240,16 @@ Runs asynchronously; failures are reported but never abort the review."
   (let ((s my-forge-ediff-review--session))
     (when (fboundp 'ghub-query)
       (ghub-query
-       my-forge-ediff-review--threads-query
-       `((owner . ,(plist-get s :owner))
-         (repo . ,(plist-get s :repo))
-         (number . ,(plist-get s :num)))
-       :auth 'forge
-       :host (plist-get s :host)
-       :callback #'my-forge-ediff-review--on-threads-fetched
-       :errorback (lambda (err &rest _)
-                    (message "Could not fetch existing review comments: %S"
-                             err))))))
+        my-forge-ediff-review--threads-query
+        `((owner . ,(plist-get s :owner))
+          (repo . ,(plist-get s :repo))
+          (number . ,(plist-get s :num)))
+        :auth 'forge
+        :host (plist-get s :host)
+        :callback #'my-forge-ediff-review--on-threads-fetched
+        :errorback (lambda (err &rest _)
+                     (message "Could not fetch existing review comments: %S"
+                              err))))))
 
 (defun my-forge-ediff-review--on-threads-fetched (response &rest _)
   "Store parsed RESPONSE into the session and refresh overlays."
@@ -602,7 +602,7 @@ HTML comments are stripped. -->\n\n"
     (message "%s saved (%d pending)."
              (my-forge-ediff-review--kind-label kind)
              (length (plist-get my-forge-ediff-review--session
-                                 (my-forge-ediff-review--kind-key kind))))))
+                                (my-forge-ediff-review--kind-key kind))))))
 
 (defun my-forge-ediff-review--store-entry (ctx kind body)
   "Store an entry of KIND with BODY at CTX into the session.
@@ -736,17 +736,17 @@ C-c C-k to cancel.  HTML comments are stripped. -->\n\n"
 Refreshes the inline overlays once GitHub confirms the change."
   (let ((s my-forge-ediff-review--session))
     (ghub-query
-     (if resolve
-         my-forge-ediff-review--resolve-mutation
-       my-forge-ediff-review--unresolve-mutation)
-     `((threadId . ,thread-id))
-     :auth 'forge
-     :host (plist-get s :host)
-     :callback (lambda (_value &rest _)
-                 (message "Thread %s." (if resolve "resolved" "unresolved"))
-                 (my-forge-ediff-review--fetch-existing-threads))
-     :errorback (lambda (err &rest _)
-                  (message "Could not update thread: %S" err)))))
+      (if resolve
+          my-forge-ediff-review--resolve-mutation
+        my-forge-ediff-review--unresolve-mutation)
+      `((threadId . ,thread-id))
+      :auth 'forge
+      :host (plist-get s :host)
+      :callback (lambda (_value &rest _)
+                  (message "Thread %s." (if resolve "resolved" "unresolved"))
+                  (my-forge-ediff-review--fetch-existing-threads))
+      :errorback (lambda (err &rest _)
+                   (message "Could not update thread: %S" err)))))
 
 ;;;; Listing / discarding
 

--- a/scripts/profile-org-agenda.el
+++ b/scripts/profile-org-agenda.el
@@ -120,7 +120,7 @@ name afterwards."
   (let* ((files-bench
           (benchmark-run 1
             (profile-org-agenda--with-quick-bindings
-              (org-agenda-files))))
+             (org-agenda-files))))
          (n-files (length (org-agenda-files))))
     (profile-org-agenda--record-line (format "agenda files: %d" n-files))
     (profile-org-agenda--record-bench "(org-agenda-files)" files-bench))
@@ -132,13 +132,13 @@ name afterwards."
   (let ((cold-bench
          (benchmark-run 1
            (profile-org-agenda--with-quick-bindings
-             (profile-org-agenda--run-target)))))
+            (profile-org-agenda--run-target)))))
     (profile-org-agenda--record-bench "agenda cold (no buffers)" cold-bench))
 
   (let ((warm-bench
          (benchmark-run 1
            (profile-org-agenda--with-quick-bindings
-             (profile-org-agenda--run-target)))))
+            (profile-org-agenda--run-target)))))
     (profile-org-agenda--record-bench "agenda warm (buffers reused)" warm-bench))
 
   ;; Persist bench summary up-front so it survives a later crash.
@@ -151,32 +151,32 @@ name afterwards."
     (message "\n=== Bench summary ===\n%s\n" bench-text)
     (message "Wrote bench to %s" bench-path))
 
-    ;; CPU profile: cold
-    (message ">> profiling cold run...")
-    (profile-org-agenda--kill-org-buffers)
-    (garbage-collect)
-    (profiler-reset)
-    (profiler-start 'cpu)
-    (profile-org-agenda--with-quick-bindings
-      (profile-org-agenda--run-target))
-    (profiler-stop)
-    (profile-org-agenda--save-report
-     (expand-file-name "org-agenda-profile-cold.txt"
-                       profile-org-agenda-output-dir))
-    (message ">> wrote cold CPU profile")
+  ;; CPU profile: cold
+  (message ">> profiling cold run...")
+  (profile-org-agenda--kill-org-buffers)
+  (garbage-collect)
+  (profiler-reset)
+  (profiler-start 'cpu)
+  (profile-org-agenda--with-quick-bindings
+   (profile-org-agenda--run-target))
+  (profiler-stop)
+  (profile-org-agenda--save-report
+   (expand-file-name "org-agenda-profile-cold.txt"
+                     profile-org-agenda-output-dir))
+  (message ">> wrote cold CPU profile")
 
-    ;; CPU profile: warm
-    (message ">> profiling warm run...")
-    (garbage-collect)
-    (profiler-reset)
-    (profiler-start 'cpu)
-    (profile-org-agenda--with-quick-bindings
-      (profile-org-agenda--run-target))
-    (profiler-stop)
-    (profile-org-agenda--save-report
-     (expand-file-name "org-agenda-profile-warm.txt"
-                       profile-org-agenda-output-dir))
-    (message ">> wrote warm CPU profile"))
+  ;; CPU profile: warm
+  (message ">> profiling warm run...")
+  (garbage-collect)
+  (profiler-reset)
+  (profiler-start 'cpu)
+  (profile-org-agenda--with-quick-bindings
+   (profile-org-agenda--run-target))
+  (profiler-stop)
+  (profile-org-agenda--save-report
+   (expand-file-name "org-agenda-profile-warm.txt"
+                     profile-org-agenda-output-dir))
+  (message ">> wrote warm CPU profile"))
 
 ;; Suppress interactive tramp prompts that init.el triggers.
 (advice-add 'yes-or-no-p :override (lambda (&rest _) t))

--- a/tests/my-forge-ediff-review-model-test.el
+++ b/tests/my-forge-ediff-review-model-test.el
@@ -48,8 +48,8 @@
                         (review-model-test--entry "a.el" 11 "RIGHT" "no")
                         (review-model-test--entry "a.el" 10 "LEFT" "no"))))
     (should (eq target
-               (my-forge-ediff-review-model-find-entry
-                entries "a.el" 10 "RIGHT")))))
+                (my-forge-ediff-review-model-find-entry
+                 entries "a.el" 10 "RIGHT")))))
 
 (ert-deftest review-model-find-entry-should-return-nil-when-absent ()
   (should-not (my-forge-ediff-review-model-find-entry

--- a/tests/my-forge-ediff-review-test.el
+++ b/tests/my-forge-ediff-review-test.el
@@ -43,90 +43,90 @@
   "Re-saving a comment on the same line replaces it instead of appending."
   (skip-unless my-forge-ediff-review-test--available)
   (my-forge-ediff-review-test--with-session (list :comments nil :memos nil)
-    (my-forge-ediff-review--store-entry
-     my-forge-ediff-review-test--ctx 'comment "first")
-    (my-forge-ediff-review--store-entry
-     my-forge-ediff-review-test--ctx 'comment "second")
-    (let ((comments (plist-get my-forge-ediff-review--session :comments)))
-      (should (= 1 (length comments)))
-      (should (equal "second" (plist-get (car comments) :body))))))
+                                            (my-forge-ediff-review--store-entry
+                                             my-forge-ediff-review-test--ctx 'comment "first")
+                                            (my-forge-ediff-review--store-entry
+                                             my-forge-ediff-review-test--ctx 'comment "second")
+                                            (let ((comments (plist-get my-forge-ediff-review--session :comments)))
+                                              (should (= 1 (length comments)))
+                                              (should (equal "second" (plist-get (car comments) :body))))))
 
 (ert-deftest my-forge-ediff-review-keeps-comments-on-different-lines ()
   "Comments on distinct lines coexist."
   (skip-unless my-forge-ediff-review-test--available)
   (my-forge-ediff-review-test--with-session (list :comments nil :memos nil)
-    (my-forge-ediff-review--store-entry
-     '(:path "a.el" :line 10 :side "RIGHT") 'comment "ten")
-    (my-forge-ediff-review--store-entry
-     '(:path "a.el" :line 20 :side "RIGHT") 'comment "twenty")
-    (should (= 2 (length (plist-get my-forge-ediff-review--session :comments))))))
+                                            (my-forge-ediff-review--store-entry
+                                             '(:path "a.el" :line 10 :side "RIGHT") 'comment "ten")
+                                            (my-forge-ediff-review--store-entry
+                                             '(:path "a.el" :line 20 :side "RIGHT") 'comment "twenty")
+                                            (should (= 2 (length (plist-get my-forge-ediff-review--session :comments))))))
 
 (ert-deftest my-forge-ediff-review-removes-comment-saved-empty ()
   "Saving an empty body removes the existing comment on that line."
   (skip-unless my-forge-ediff-review-test--available)
   (my-forge-ediff-review-test--with-session
-      (list :comments (list (append my-forge-ediff-review-test--ctx
-                                    (list :body "old")))
-            :memos nil)
-    (my-forge-ediff-review--store-entry
-     my-forge-ediff-review-test--ctx 'comment "")
-    (should (null (plist-get my-forge-ediff-review--session :comments)))))
+   (list :comments (list (append my-forge-ediff-review-test--ctx
+                                 (list :body "old")))
+         :memos nil)
+   (my-forge-ediff-review--store-entry
+    my-forge-ediff-review-test--ctx 'comment "")
+   (should (null (plist-get my-forge-ediff-review--session :comments)))))
 
 (ert-deftest my-forge-ediff-review-prefills-existing-comment-body ()
   "Reopening the editor on a commented line returns its body for prefill."
   (skip-unless my-forge-ediff-review-test--available)
   (my-forge-ediff-review-test--with-session
-      (list :comments (list (append my-forge-ediff-review-test--ctx
-                                    (list :body "draft")))
-            :memos nil)
-    (should (equal "draft"
-                   (my-forge-ediff-review--existing-entry-body
-                    my-forge-ediff-review-test--ctx 'comment)))))
+   (list :comments (list (append my-forge-ediff-review-test--ctx
+                                 (list :body "draft")))
+         :memos nil)
+   (should (equal "draft"
+                  (my-forge-ediff-review--existing-entry-body
+                   my-forge-ediff-review-test--ctx 'comment)))))
 
 (ert-deftest my-forge-ediff-review-still-replaces-existing-memo ()
   "Memo behaviour is unchanged: one editable memo per line."
   (skip-unless my-forge-ediff-review-test--available)
   (my-forge-ediff-review-test--with-session (list :comments nil :memos nil)
-    (my-forge-ediff-review--store-entry
-     my-forge-ediff-review-test--ctx 'memo "m1")
-    (my-forge-ediff-review--store-entry
-     my-forge-ediff-review-test--ctx 'memo "m2")
-    (let ((memos (plist-get my-forge-ediff-review--session :memos)))
-      (should (= 1 (length memos)))
-      (should (equal "m2" (plist-get (car memos) :body))))))
+                                            (my-forge-ediff-review--store-entry
+                                             my-forge-ediff-review-test--ctx 'memo "m1")
+                                            (my-forge-ediff-review--store-entry
+                                             my-forge-ediff-review-test--ctx 'memo "m2")
+                                            (let ((memos (plist-get my-forge-ediff-review--session :memos)))
+                                              (should (= 1 (length memos)))
+                                              (should (equal "m2" (plist-get (car memos) :body))))))
 
 (ert-deftest my-forge-ediff-review-dims-diff-faces-when-session-active ()
   "Softening remaps every diff face to a background-only spec locally."
   (skip-unless my-forge-ediff-review-test--available)
   (with-temp-buffer
     (my-forge-ediff-review-test--with-session (list :comments nil :memos nil)
-      (let ((my-forge-ediff-review-dim-diff-faces t))
-        (my-forge-ediff-review--dim-diff-faces)
-        (should (local-variable-p 'face-remapping-alist))
-        (dolist (pair my-forge-ediff-review--dim-diff-faces)
-          ;; The face is remapped and the remap only touches the
-          ;; background, leaving the font-lock foreground intact.
-          (should (assq (car pair) face-remapping-alist))
-          (should (plist-get (cdr pair) :background))
-          (should-not (plist-get (cdr pair) :foreground)))))))
+                                              (let ((my-forge-ediff-review-dim-diff-faces t))
+                                                (my-forge-ediff-review--dim-diff-faces)
+                                                (should (local-variable-p 'face-remapping-alist))
+                                                (dolist (pair my-forge-ediff-review--dim-diff-faces)
+                                                  ;; The face is remapped and the remap only touches the
+                                                  ;; background, leaving the font-lock foreground intact.
+                                                  (should (assq (car pair) face-remapping-alist))
+                                                  (should (plist-get (cdr pair) :background))
+                                                  (should-not (plist-get (cdr pair) :foreground)))))))
 
 (ert-deftest my-forge-ediff-review-does-not-dim-when-disabled ()
   "No remap happens when softening is turned off."
   (skip-unless my-forge-ediff-review-test--available)
   (with-temp-buffer
     (my-forge-ediff-review-test--with-session (list :comments nil :memos nil)
-      (let ((my-forge-ediff-review-dim-diff-faces nil))
-        (my-forge-ediff-review--dim-diff-faces)
-        (should-not (assq 'ediff-current-diff-A face-remapping-alist))))))
+                                              (let ((my-forge-ediff-review-dim-diff-faces nil))
+                                                (my-forge-ediff-review--dim-diff-faces)
+                                                (should-not (assq 'ediff-current-diff-A face-remapping-alist))))))
 
 (ert-deftest my-forge-ediff-review-does-not-dim-without-session ()
   "No remap happens outside an active review session."
   (skip-unless my-forge-ediff-review-test--available)
   (with-temp-buffer
     (my-forge-ediff-review-test--with-session nil
-      (let ((my-forge-ediff-review-dim-diff-faces t))
-        (my-forge-ediff-review--dim-diff-faces)
-        (should-not (assq 'ediff-current-diff-A face-remapping-alist))))))
+                                              (let ((my-forge-ediff-review-dim-diff-faces t))
+                                                (my-forge-ediff-review--dim-diff-faces)
+                                                (should-not (assq 'ediff-current-diff-A face-remapping-alist))))))
 
 (provide 'my-forge-ediff-review-test)
 ;;; my-forge-ediff-review-test.el ends here

--- a/tests/my-vterm-toggle-test.el
+++ b/tests/my-vterm-toggle-test.el
@@ -88,79 +88,79 @@ BODY can inspect the recorded action symbols in the variable `calls'
 
 (ert-deftest my-vterm-toggle-should-hide-when-focused-on-vterm ()
   (my-vterm-toggle-test--with-stubs
-      (:focused-on-vterm t :current-frame-window stub-window :window-deletable t)
-    (my-vterm-toggle)
-    (should (equal calls '(hide)))))
+   (:focused-on-vterm t :current-frame-window stub-window :window-deletable t)
+   (my-vterm-toggle)
+   (should (equal calls '(hide)))))
 
 (ert-deftest my-vterm-toggle-should-delete-frame-when-vterm-is-sole-window ()
   ;; `window-deletable-p' returns the symbol `frame' for a frame's sole
   ;; window; `vterm-toggle-hide' would signal an error there.
   (my-vterm-toggle-test--with-stubs
-      (:focused-on-vterm t :current-frame-window stub-window :window-deletable frame)
-    (my-vterm-toggle)
-    (should (equal calls '(delete-frame)))))
+   (:focused-on-vterm t :current-frame-window stub-window :window-deletable frame)
+   (my-vterm-toggle)
+   (should (equal calls '(delete-frame)))))
 
 (ert-deftest my-vterm-toggle-should-fall-back-to-hide-on-last-frame ()
   ;; Sole window on the last visible frame: `window-deletable-p' is nil,
   ;; so defer to `vterm-toggle-hide' which buries the buffer.
   (my-vterm-toggle-test--with-stubs
-      (:focused-on-vterm t :current-frame-window stub-window :window-deletable nil)
-    (my-vterm-toggle)
-    (should (equal calls '(hide)))))
+   (:focused-on-vterm t :current-frame-window stub-window :window-deletable nil)
+   (my-vterm-toggle)
+   (should (equal calls '(hide)))))
 
 (ert-deftest my-vterm-toggle-should-spawn-new-vterm-with-prefix-in-vterm ()
   (my-vterm-toggle-test--with-stubs
-      (:focused-on-vterm t :current-frame-window stub-window :window-deletable t)
-    (my-vterm-toggle '(4))
-    (should (equal calls '(new-vterm)))))
+   (:focused-on-vterm t :current-frame-window stub-window :window-deletable t)
+   (my-vterm-toggle '(4))
+   (should (equal calls '(new-vterm)))))
 
 ;;; State 2: vterm visible but focus elsewhere -> focus it.
 
 (ert-deftest my-vterm-toggle-should-focus-vterm-window-on-current-frame ()
   (my-vterm-toggle-test--with-stubs
-      (:current-frame-window stub-window)
-    (my-vterm-toggle)
-    (should (equal calls '((select-window . stub-window))))))
+   (:current-frame-window stub-window)
+   (my-vterm-toggle)
+   (should (equal calls '((select-window . stub-window))))))
 
 (ert-deftest my-vterm-toggle-should-not-hide-unfocused-vterm-on-current-frame ()
   (my-vterm-toggle-test--with-stubs
-      (:current-frame-window stub-window)
-    (my-vterm-toggle)
-    (should-not (memq 'hide calls))))
+   (:current-frame-window stub-window)
+   (my-vterm-toggle)
+   (should-not (memq 'hide calls))))
 
 (ert-deftest my-vterm-toggle-should-focus-frame-showing-vterm-on-other-frame ()
   (my-vterm-toggle-test--with-stubs
-      (:other-frame-window stub-window)
-    (my-vterm-toggle)
-    (should (equal calls
-                   '((select-window . stub-window)
-                     (focus-frame . stub-frame))))))
+   (:other-frame-window stub-window)
+   (my-vterm-toggle)
+   (should (equal calls
+                  '((select-window . stub-window)
+                    (focus-frame . stub-frame))))))
 
 (ert-deftest my-vterm-toggle-should-not-hide-vterm-shown-on-other-frame ()
   (my-vterm-toggle-test--with-stubs
-      (:other-frame-window stub-window)
-    (my-vterm-toggle)
-    (should-not (memq 'hide calls))))
+   (:other-frame-window stub-window)
+   (my-vterm-toggle)
+   (should-not (memq 'hide calls))))
 
 (ert-deftest my-vterm-toggle-should-not-reshow-vterm-shown-on-other-frame ()
   (my-vterm-toggle-test--with-stubs
-      (:other-frame-window stub-window)
-    (my-vterm-toggle)
-    (should-not (memq 'show calls))))
+   (:other-frame-window stub-window)
+   (my-vterm-toggle)
+   (should-not (memq 'show calls))))
 
 (ert-deftest my-vterm-toggle-should-prefer-current-frame-window-over-other-frame ()
   (my-vterm-toggle-test--with-stubs
-      (:current-frame-window stub-window :other-frame-window other-window)
-    (my-vterm-toggle)
-    (should (equal calls '((select-window . stub-window))))))
+   (:current-frame-window stub-window :other-frame-window other-window)
+   (my-vterm-toggle)
+   (should (equal calls '((select-window . stub-window))))))
 
 ;;; State 3: vterm not visible anywhere -> show.
 
 (ert-deftest my-vterm-toggle-should-show-when-vterm-not-visible-anywhere ()
   (my-vterm-toggle-test--with-stubs
-      ()
-    (my-vterm-toggle)
-    (should (equal calls '(show)))))
+   ()
+   (my-vterm-toggle)
+   (should (equal calls '(show)))))
 
 ;;; Helper: other-frame window lookup.
 


### PR DESCRIPTION
## Format buffers on save without moving point

Formatting used to run on demand only, through `C-c f` -> `my-lsp-format`, which
went out to the language server. apheleia replaces that path: it runs an external
formatter asynchronously and applies the result as a diff, so a save never moves
point or scrolls the window.

`C-c f` keeps working and now runs `apheleia-format-buffer`. Region formatting
(`lsp-format-region`) goes away, because apheleia only formats whole buffers.

`:demand t` is required here. With `:bind` alone, use-package would defer loading
until the first `C-c f`, leaving `apheleia-global-mode` off until then.

## Reindent every Emacs Lisp file up front

apheleia formats `emacs-lisp-mode` with `lisp-indent`, so every `.el` file in this
repository would pick up indentation changes on its next save. Applying that once
here keeps later commits free of unrelated churn.

That commit is whitespace-only: `git diff -w` reports no difference, and the
formatter leaves every file untouched on a second run. It accounts for 241 of the
287 changed lines, which is why this PR is bigger than the usual target.

## Use ruff for Python instead of the apheleia default

apheleia maps `python-mode` to black, which is not installed on this machine, so
Python buffers would quietly stay unformatted. ruff is installed, so point both
`python-mode` and `python-ts-mode` at it.

## Verified end to end

Each language formatted a deliberately misformatted sample through apheleia:

| Language | Formatter | Result |
| --- | --- | --- |
| Python | ruff | formatted |
| C / C++ / Obj-C | clang-format | formatted |
| Go | gofmt | formatted |
| TypeScript | prettier | not formatted, prettier is absent |

prettier resolves from the project's `node_modules` before `PATH`, so TypeScript
is formatted only inside a project that carries prettier itself. apheleia calls
`executable-find` before running a formatter and skips the buffer when the command
is missing, so an absent formatter costs nothing beyond leaving the buffer alone.

Byte-compiling `init.el` passes. The ERT suite reports 83/83 under `TZ=UTC`, which
is what CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)