### PR TITLE
Fix Org table misalignment with Japanese text

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ Configuration is split into focused modules in the `lisp/` directory:
 
 Each module is loaded via `(require 'init-*)` in `init.el`.
 
+## Fonts
+
+`init-ui.el` picks the default face from `my-font-candidates`, taking the first
+family that is actually installed. The head of that list is deliberately made up
+of Japanese-capable monospace families whose full-width glyphs are exactly twice
+as wide as the half-width ones. Org needs that 1:2 ratio: `org-table-align` pads
+cells by `string-width`, which counts a full-width character as two columns, so
+any other ratio makes the `|` separators of a table containing Japanese drift
+apart row by row.
+
+Nothing is installed automatically — if none of the preferred families are
+present the configuration falls back to Monaco and tries to repair the ratio via
+`face-font-rescale-alist`, which pixel rounding can only get so close. To get it
+exact, install one of them, e.g. on macOS:
+
+```sh
+brew install --cask font-hackgen-nerd
+```
+
+Run `M-x my-check-cjk-font-ratio` to check the result: it reports the measured
+full-width/half-width ratio, which should be `2.000`.
+
 ## Scripts
 
 Helper scripts kept under `scripts/`. They are not loaded automatically by Emacs; run them manually as described below.

--- a/README.md
+++ b/README.md
@@ -36,21 +36,28 @@ Each module is loaded via `(require 'init-*)` in `init.el`.
 ## Fonts
 
 `init-ui.el` picks the default face from `my-font-candidates`, taking the first
-family that is actually installed. The head of that list is deliberately made up
-of Japanese-capable monospace families whose full-width glyphs are exactly twice
-as wide as the half-width ones. Org needs that 1:2 ratio: `org-table-align` pads
-cells by `string-width`, which counts a full-width character as two columns, so
-any other ratio makes the `|` separators of a table containing Japanese drift
-apart row by row.
+family that is actually installed. Monaco heads the list.
 
-Nothing is installed automatically — if none of the preferred families are
-present the configuration falls back to Monaco and tries to repair the ratio via
-`face-font-rescale-alist`, which pixel rounding can only get so close. To get it
-exact, install one of them, e.g. on macOS:
+Monaco carries no Japanese glyphs, so Japanese falls back to another family
+whose advance width has nothing to do with Monaco's. That breaks Org tables:
+`org-table-align` pads cells by `string-width`, which counts a full-width
+character as two columns, so at any ratio other than 1:2 the `|` separators of a
+table containing Japanese drift apart row by row.
 
-```sh
-brew install --cask font-hackgen-nerd
-```
+`my-tune-cjk-font` fixes this by pinning the Japanese family (Hiragino Sans and
+friends, see `my-cjk-fallback-font-candidates`) to an explicit pixel size of
+twice `frame-char-width` — a full-width glyph advances by its em box, so that
+size makes it occupy exactly two columns. It runs at startup and again after
+every `text-scale+` / `text-scale-` / `text-scale0`, since the pinned size is
+absolute and cannot follow the ASCII font by itself.
+
+The trade-off of keeping Monaco: Monaco advances only about 0.6 em, so twice
+that is ~1.2 em and the Japanese font ends up visibly larger than the ASCII one.
+Lines containing Japanese are therefore taller than pure-ASCII lines. Families
+further down `my-font-candidates` (HackGen, UDEV Gothic, PlemolJP, Cica, …) ship
+Japanese glyphs at exactly twice the half-width advance and need no tuning at
+all, at the cost of not being Monaco; installing one and moving it to the front
+of the list is all it takes to switch.
 
 Run `M-x my-check-cjk-font-ratio` to check the result: it reports the measured
 full-width/half-width ratio, which should be `2.000`.

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -286,6 +286,48 @@ Date format is YYYY-MM-DD.")
     (custom-set-faces `(org-document-title ((t (:family ,default-font :height 1.0 :weight bold :inherit default)))))
     )
 
+  ;; Line wrapping and tables do not mix: a row wider than the window gets
+  ;; folded in the middle, so the columns are unreadable even once the font
+  ;; gets the full-width/half-width ratio right (see `my-font-candidates' in
+  ;; init-ui.el).  Emacs has no per-line `truncate-lines', so wrapping is
+  ;; switched off for the whole buffer while point sits inside a table and
+  ;; restored on the way out.
+  ;; For tables that are permanently too wide, Org's own column shrinking is
+  ;; the complementary answer and needs no code at all: `C-c TAB'
+  ;; (`org-table-toggle-column-width'), `| <10> | <30> |' width cookies in
+  ;; the first row, or `#+STARTUP: shrink'.
+  (defvar-local my-org-auto-inhibit-table-wrap t
+    "When non-nil, disable line wrapping while point is inside an Org table.
+Set to nil by `my-org-toggle-line-wrap' so a manual choice sticks.")
+
+  (defun my-org-table-inhibit-wrap ()
+    "Turn wrapping off inside Org tables and back on outside them."
+    (when (and my-org-auto-inhibit-table-wrap
+               (derived-mode-p 'org-mode))
+      (let ((in-table (org-at-table-p)))
+        (cond ((and in-table (not truncate-lines))
+               ;; Disable first: `visual-line-mode' restores the saved
+               ;; `truncate-lines' on the way out, which would undo this.
+               (visual-line-mode -1)
+               (setq-local truncate-lines t))
+              ((and (not in-table) truncate-lines)
+               (setq-local truncate-lines nil)
+               (visual-line-mode 1))))))
+
+  (defun my-org-toggle-line-wrap ()
+    "Toggle line wrapping in the current buffer, and stop auto-toggling.
+Without disabling `my-org-auto-inhibit-table-wrap', the in-table switching
+done by `my-org-table-inhibit-wrap' would undo this on the next command."
+    (interactive)
+    (setq-local my-org-auto-inhibit-table-wrap nil)
+    (if visual-line-mode
+        (progn (visual-line-mode -1)
+               (setq-local truncate-lines t))
+      (setq-local truncate-lines nil)
+      (visual-line-mode 1))
+    (message "Line wrapping %s (automatic in-table switching disabled)"
+             (if visual-line-mode "on" "off")))
+
   :bind (("C-c c" . 'org-capture)
          ("C-M-c" . 'org/note-right-now)
          ("C-c /" . 'consult-org-agenda)
@@ -293,10 +335,15 @@ Date format is YYYY-MM-DD.")
          :map org-mode-map
          ("M-e" . 'my-org-mode-wrap-inline-code)
          ("C-c /" . 'consult-org-agenda)
+         ("C-c w" . 'my-org-toggle-line-wrap)
          ("C-c s" . 'org-store-link))
   :hook ((org-mode . (lambda ()
                        ;; To wrap texts
                        (visual-line-mode)
+                       ;; ... except inside tables, where wrapping destroys
+                       ;; the column alignment.
+                       (add-hook 'post-command-hook
+                                 #'my-org-table-inhibit-wrap nil t)
                        ;; Enable only under org-directory
                        (when (and buffer-file-name
                                   (string-prefix-p org-directory

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -22,6 +22,10 @@
     (setq org-directory (expand-file-name "~/ghq/github.com/garaemon/org/")))
   :custom
   (org-startup-indented t)
+  ;; Org's default, made explicit because it is load-bearing here: wrapping a
+  ;; table row wider than the window folds it in the middle and destroys the
+  ;; column alignment.  See `my-org-toggle-line-wrap'.
+  (org-startup-truncated t)
   (org-hide-emphasis-markers t)
   (org-startup-with-latex-preview nil)
   (org-link-file-path-type 'relative)
@@ -287,46 +291,25 @@ Date format is YYYY-MM-DD.")
     )
 
   ;; Line wrapping and tables do not mix: a row wider than the window gets
-  ;; folded in the middle, so the columns are unreadable even once the font
-  ;; gets the full-width/half-width ratio right (see `my-font-candidates' in
-  ;; init-ui.el).  Emacs has no per-line `truncate-lines', so wrapping is
-  ;; switched off for the whole buffer while point sits inside a table and
-  ;; restored on the way out.
-  ;; For tables that are permanently too wide, Org's own column shrinking is
-  ;; the complementary answer and needs no code at all: `C-c TAB'
+  ;; folded in the middle, which destroys the column alignment the font setup
+  ;; works to preserve (see `my-font-candidates' in init-ui.el).  Emacs has no
+  ;; per-line `truncate-lines', so this is all-or-nothing per buffer -- Org
+  ;; buffers do not wrap, and long prose runs off the right edge instead.
+  ;; For a table too wide to scroll around comfortably, Org's own column
+  ;; shrinking is the complementary answer and needs no code at all: `C-c TAB'
   ;; (`org-table-toggle-column-width'), `| <10> | <30> |' width cookies in
   ;; the first row, or `#+STARTUP: shrink'.
-  (defvar-local my-org-auto-inhibit-table-wrap t
-    "When non-nil, disable line wrapping while point is inside an Org table.
-Set to nil by `my-org-toggle-line-wrap' so a manual choice sticks.")
-
-  (defun my-org-table-inhibit-wrap ()
-    "Turn wrapping off inside Org tables and back on outside them."
-    (when (and my-org-auto-inhibit-table-wrap
-               (derived-mode-p 'org-mode))
-      (let ((in-table (org-at-table-p)))
-        (cond ((and in-table (not truncate-lines))
-               ;; Disable first: `visual-line-mode' restores the saved
-               ;; `truncate-lines' on the way out, which would undo this.
-               (visual-line-mode -1)
-               (setq-local truncate-lines t))
-              ((and (not in-table) truncate-lines)
-               (setq-local truncate-lines nil)
-               (visual-line-mode 1))))))
-
   (defun my-org-toggle-line-wrap ()
-    "Toggle line wrapping in the current buffer, and stop auto-toggling.
-Without disabling `my-org-auto-inhibit-table-wrap', the in-table switching
-done by `my-org-table-inhibit-wrap' would undo this on the next command."
+    "Toggle line wrapping in the current buffer.
+Off by default in Org (see `org-startup-truncated') so that wide tables
+keep their alignment; turn it on for a buffer that is mostly long prose."
     (interactive)
-    (setq-local my-org-auto-inhibit-table-wrap nil)
     (if visual-line-mode
         (progn (visual-line-mode -1)
                (setq-local truncate-lines t))
       (setq-local truncate-lines nil)
       (visual-line-mode 1))
-    (message "Line wrapping %s (automatic in-table switching disabled)"
-             (if visual-line-mode "on" "off")))
+    (message "Line wrapping %s" (if visual-line-mode "on" "off")))
 
   :bind (("C-c c" . 'org-capture)
          ("C-M-c" . 'org/note-right-now)
@@ -338,12 +321,10 @@ done by `my-org-table-inhibit-wrap' would undo this on the next command."
          ("C-c w" . 'my-org-toggle-line-wrap)
          ("C-c s" . 'org-store-link))
   :hook ((org-mode . (lambda ()
-                       ;; To wrap texts
-                       (visual-line-mode)
-                       ;; ... except inside tables, where wrapping destroys
-                       ;; the column alignment.
-                       (add-hook 'post-command-hook
-                                 #'my-org-table-inhibit-wrap nil t)
+                       ;; No `visual-line-mode' here: `org-startup-truncated'
+                       ;; already leaves `truncate-lines' on, which is what
+                       ;; keeps wide tables readable.  `C-c w' turns wrapping
+                       ;; on for the odd prose-heavy buffer.
                        ;; Enable only under org-directory
                        (when (and buffer-file-name
                                   (string-prefix-p org-directory

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -23,8 +23,14 @@
   :custom
   (org-startup-indented t)
   ;; Org's default, made explicit because it is load-bearing here: wrapping a
-  ;; table row wider than the window folds it in the middle and destroys the
-  ;; column alignment.  See `my-org-toggle-line-wrap'.
+  ;; table row wider than the window folds it in the middle, which destroys
+  ;; the column alignment the font setup works to preserve (see
+  ;; `my-font-candidates' in init-ui.el).  Emacs has no per-line
+  ;; `truncate-lines', so this is all-or-nothing per buffer -- long prose runs
+  ;; off the right edge instead of wrapping.  For a table too wide to scroll
+  ;; around comfortably, Org's own column shrinking is the complementary
+  ;; answer: `C-c TAB' (`org-table-toggle-column-width'), `| <10> | <30> |'
+  ;; width cookies in the first row, or `#+STARTUP: shrink'.
   (org-startup-truncated t)
   (org-hide-emphasis-markers t)
   (org-startup-with-latex-preview nil)
@@ -290,27 +296,6 @@ Date format is YYYY-MM-DD.")
     (custom-set-faces `(org-document-title ((t (:family ,default-font :height 1.0 :weight bold :inherit default)))))
     )
 
-  ;; Line wrapping and tables do not mix: a row wider than the window gets
-  ;; folded in the middle, which destroys the column alignment the font setup
-  ;; works to preserve (see `my-font-candidates' in init-ui.el).  Emacs has no
-  ;; per-line `truncate-lines', so this is all-or-nothing per buffer -- Org
-  ;; buffers do not wrap, and long prose runs off the right edge instead.
-  ;; For a table too wide to scroll around comfortably, Org's own column
-  ;; shrinking is the complementary answer and needs no code at all: `C-c TAB'
-  ;; (`org-table-toggle-column-width'), `| <10> | <30> |' width cookies in
-  ;; the first row, or `#+STARTUP: shrink'.
-  (defun my-org-toggle-line-wrap ()
-    "Toggle line wrapping in the current buffer.
-Off by default in Org (see `org-startup-truncated') so that wide tables
-keep their alignment; turn it on for a buffer that is mostly long prose."
-    (interactive)
-    (if visual-line-mode
-        (progn (visual-line-mode -1)
-               (setq-local truncate-lines t))
-      (setq-local truncate-lines nil)
-      (visual-line-mode 1))
-    (message "Line wrapping %s" (if visual-line-mode "on" "off")))
-
   :bind (("C-c c" . 'org-capture)
          ("C-M-c" . 'org/note-right-now)
          ("C-c /" . 'consult-org-agenda)
@@ -318,17 +303,8 @@ keep their alignment; turn it on for a buffer that is mostly long prose."
          :map org-mode-map
          ("M-e" . 'my-org-mode-wrap-inline-code)
          ("C-c /" . 'consult-org-agenda)
-         ("C-c w" . 'my-org-toggle-line-wrap)
          ("C-c s" . 'org-store-link))
   :hook ((org-mode . (lambda ()
-                       ;; Do not wrap -- folding a wide table row in the
-                       ;; middle destroys its column alignment.  `C-c w'
-                       ;; turns wrapping on for the odd prose-heavy buffer.
-                       ;; `org-startup-truncated' is supposed to cover this,
-                       ;; but it is read in the body of `org-mode' and so
-                       ;; loses to anything that runs later; setting it from
-                       ;; the hook is what actually sticks.
-                       (setq-local truncate-lines t)
                        ;; Enable only under org-directory
                        (when (and buffer-file-name
                                   (string-prefix-p org-directory

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -321,10 +321,14 @@ keep their alignment; turn it on for a buffer that is mostly long prose."
          ("C-c w" . 'my-org-toggle-line-wrap)
          ("C-c s" . 'org-store-link))
   :hook ((org-mode . (lambda ()
-                       ;; No `visual-line-mode' here: `org-startup-truncated'
-                       ;; already leaves `truncate-lines' on, which is what
-                       ;; keeps wide tables readable.  `C-c w' turns wrapping
-                       ;; on for the odd prose-heavy buffer.
+                       ;; Do not wrap -- folding a wide table row in the
+                       ;; middle destroys its column alignment.  `C-c w'
+                       ;; turns wrapping on for the odd prose-heavy buffer.
+                       ;; `org-startup-truncated' is supposed to cover this,
+                       ;; but it is read in the body of `org-mode' and so
+                       ;; loses to anything that runs later; setting it from
+                       ;; the hook is what actually sticks.
+                       (setq-local truncate-lines t)
                        ;; Enable only under org-directory
                        (when (and buffer-file-name
                                   (string-prefix-p org-directory

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -6,8 +6,138 @@
 ;;; Code:
 
 ;;; GUI settings
+(require 'seq)
+
 (defvar my-default-face-height 100
   "Default face height in 1/10 pt.  Set per-display in the platform blocks.")
+
+(defvar my-font-candidates
+  '(;; Japanese-capable monospace families whose full-width glyphs are
+    ;; exactly twice as wide as the half-width ones.  This ratio is what
+    ;; makes Org tables containing Japanese line up: `org-table-align' pads
+    ;; cells by `string-width', which counts a full-width character as two
+    ;; columns.  If the rendered ratio is anything other than 1:2, the `|'
+    ;; separators drift further apart on every row.
+    "HackGen Console NF"
+    "HackGen35 Console NF"
+    "HackGen"
+    "UDEV Gothic NF"
+    "UDEV Gothic"
+    "PlemolJP Console NF"
+    "PlemolJP"
+    "Cica"
+    "Ricty Diminished"
+    ;; Fallbacks.  These are ASCII-only, so Japanese falls back to whatever
+    ;; the system picks (Hiragino on macOS) at an unrelated advance width;
+    ;; `my-tune-cjk-font' repairs the ratio as best it can in that case.
+    "Monaco Nerd Font Mono"
+    "Monaco")
+  "Font families for the default face, most preferred first.
+The first family that is actually installed wins, so an entry that is not
+present on this machine simply falls through to the next one.")
+
+(defvar my-cjk-fallback-font-candidates
+  '("HackGen" "UDEV Gothic" "PlemolJP" "Cica" "Ricty Diminished"
+    "Hiragino Sans" "Hiragino Kaku Gothic ProN"
+    "Noto Sans Mono CJK JP" "Noto Sans CJK JP" "IPAGothic")
+  "Japanese families to pin when the default face font has no CJK glyphs.")
+
+(defun my-first-available-font (candidates)
+  "Return the first family in CANDIDATES that is installed, or nil."
+  (seq-find (lambda (family) (find-font (font-spec :family family))) candidates))
+
+(defun my-cjk-font-width-ratio ()
+  "Return rendered width of a full-width char divided by a half-width one.
+Return nil when the width cannot be measured (non-graphical display).  A
+value of 2.0 is what Org tables with Japanese text need; see
+`my-font-candidates'."
+  (when (and (display-graphic-p) (fboundp 'string-pixel-width))
+    (let ((half (string-pixel-width "aa"))
+          (full (string-pixel-width "ああ")))
+      (when (> half 0)
+        (/ (float full) half)))))
+
+(defun my-check-cjk-font-ratio ()
+  "Report whether full-width chars render at exactly twice the half-width.
+Use this to verify the font setup instead of eyeballing a table."
+  (interactive)
+  (let ((ratio (my-cjk-font-width-ratio)))
+    (cond
+     ((null ratio)
+      (message "Cannot measure glyph widths on this display."))
+     ((< (abs (- ratio 2.0)) 0.02)
+      (message "Full/half width ratio is %.3f -- Org tables with Japanese line up."
+               ratio))
+     (t
+      (message "Full/half width ratio is %.3f (want 2.000) -- Org tables with Japanese will drift. Install e.g. %s"
+               ratio (car my-font-candidates))))))
+
+(defun my--set-font-rescale (family factor)
+  "Rescale FAMILY by FACTOR via `face-font-rescale-alist'.
+The alist is keyed by a regexp matched against the full font name, so the
+quoted family name is used as a substring pattern."
+  (let ((key (regexp-quote family)))
+    (setq face-font-rescale-alist
+          (cons (cons key factor)
+                (assoc-delete-all key face-font-rescale-alist)))))
+
+(defun my-tune-cjk-font ()
+  "Correct the CJK/ASCII width ratio to 1:2 when the current font misses it.
+No-op when the ratio is already right, which is the case for every family
+at the head of `my-font-candidates'.  Otherwise the default family has no
+Japanese glyphs, Emacs is falling back to some other family whose advance
+width has no relation to the ASCII one, and this pins that fallback and
+scales it until a full-width character occupies two columns.  The scaling
+is only as exact as integer pixel rounding allows; installing a 1:2 family
+is the real fix."
+  (interactive)
+  (let ((ratio (my-cjk-font-width-ratio)))
+    (when (and ratio (> (abs (- ratio 2.0)) 0.02))
+      (let ((family (my-first-available-font my-cjk-fallback-font-candidates)))
+        (when family
+          (dolist (charset '(japanese-jisx0208 japanese-jisx0212
+                             katakana-jisx0201 kana han cjk-misc))
+            (set-fontset-font t charset (font-spec :family family) nil 'prepend))
+          ;; Measure with a neutral scale first, then apply the correction
+          ;; the measurement asks for.
+          (my--set-font-rescale family 1.0)
+          (clear-face-cache)
+          (let ((measured (my-cjk-font-width-ratio)))
+            (when (and measured (> measured 0))
+              (my--set-font-rescale family (/ 2.0 measured))
+              (clear-face-cache)))
+          ;; Pixel rounding can leave a residual error that no rescaling
+          ;; factor removes.  Say so once rather than letting the tables
+          ;; silently stay crooked.
+          (let ((final (my-cjk-font-width-ratio)))
+            (when (and final (> (abs (- final 2.0)) 0.02))
+              (message "Full/half width ratio is %.3f after rescaling %s; install e.g. %s (M-x my-check-cjk-font-ratio)"
+                       final family (car my-font-candidates)))))))))
+
+(defun my-apply-default-font (family)
+  "Apply FAMILY to the default face and seed `default-frame-alist'."
+  ;; Set the default face's family/height explicitly rather than only
+  ;; the frame `font' parameter via `set-frame-font'.  With just the
+  ;; frame parameter, the default face's `:family' stays unspecified, so
+  ;; `(face-attribute 'default :font)' is unstable: creating a child
+  ;; frame (e.g. vertico-posframe on the first `C-x b') re-resolves it to
+  ;; the macOS default proportional font (Helvetica), which then leaks
+  ;; into normal buffers like dired.  An explicit family keeps it put.
+  (set-face-attribute 'default nil :family family :height my-default-face-height)
+  ;; NOTE: seed `default-frame-alist' with a plain font string rather than
+  ;; calling `set-frame-font' here -- re-applying the font on the running
+  ;; frame at startup reintroduces the very fallback this guards against.
+  (setf (alist-get 'font default-frame-alist)
+        (format "%s-%d" family (/ my-default-face-height 10))))
+
+(defun my-setup-fonts ()
+  "Pick the best installed family from `my-font-candidates' and apply it."
+  (let ((family (my-first-available-font my-font-candidates)))
+    (when family
+      (my-apply-default-font family)))
+  ;; Defer the width check until the initial frame is fully set up --
+  ;; `string-pixel-width' needs a live window to measure against.
+  (add-hook 'window-setup-hook #'my-tune-cjk-font))
 
 (when-darwin
  (when (display-graphic-p)
@@ -15,19 +145,6 @@
    (if (> (x-display-pixel-width) 1440)
        (setq my-default-face-height 120)
      (setq my-default-face-height 100))
-   ;; Set the default face's family/height explicitly rather than only
-   ;; the frame `font' parameter via `set-frame-font'.  With just the
-   ;; frame parameter, the default face's `:family' stays unspecified, so
-   ;; `(face-attribute 'default :font)' is unstable: creating a child
-   ;; frame (e.g. vertico-posframe on the first `C-x b') re-resolves it to
-   ;; the macOS default proportional font (Helvetica), which then leaks
-   ;; into normal buffers like dired.  An explicit family keeps it Monaco.
-   ;; NOTE: seed `default-frame-alist' with a plain font string rather than
-   ;; calling `set-frame-font' here -- re-applying the font on the running
-   ;; frame at startup reintroduces the very fallback this guards against.
-   (set-face-attribute 'default nil :family "Monaco" :height my-default-face-height)
-   (add-to-list 'default-frame-alist
-                (cons 'font (format "Monaco-%d" (/ my-default-face-height 10))))
    (setq ns-command-modifier (quote meta))
    (setq ns-alternate-modifier (quote super))
    ;; Do not pass control key to mac OS X
@@ -39,19 +156,13 @@
    (define-key global-map [?¥] [?\\])
    ))
 
-(when (eq system-type 'gnu/linux)
-  (set-face-attribute 'default nil
-                      :height my-default-face-height)
-  ;; TODO: mirror the darwin block here -- set `:family' on the default
-  ;; face and seed `default-frame-alist' so posframe child frames do not
-  ;; re-resolve to a proportional fallback.  Left as-is for now since this
-  ;; path is untested on the current (macOS) machine.
-  (let ((font "Monaco Nerd Font Mono"))
-    (if (find-font (font-spec :name font))
-        (set-frame-font font 12)))
-  ;; special key as meta
-  ;; (setq x-super-keysym 'meta)
-  )
+;; On GNU/Linux, to use the special key as meta:
+;; (setq x-super-keysym 'meta)
+
+;; Must run after the platform blocks above, which set
+;; `my-default-face-height'.
+(when (display-graphic-p)
+  (my-setup-fonts))
 
 ;;; Text scale functions
 (defun text-scale+ ()

--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -12,12 +12,17 @@
   "Default face height in 1/10 pt.  Set per-display in the platform blocks.")
 
 (defvar my-font-candidates
-  '(;; Japanese-capable monospace families whose full-width glyphs are
-    ;; exactly twice as wide as the half-width ones.  This ratio is what
-    ;; makes Org tables containing Japanese line up: `org-table-align' pads
+  '(;; Monaco first -- it is simply the most readable of the lot.  It has no
+    ;; Japanese glyphs, so Japanese falls back to another family whose
+    ;; advance width has nothing to do with Monaco's; `my-tune-cjk-font'
+    ;; below fixes that up.  Org needs the fix because `org-table-align' pads
     ;; cells by `string-width', which counts a full-width character as two
-    ;; columns.  If the rendered ratio is anything other than 1:2, the `|'
-    ;; separators drift further apart on every row.
+    ;; columns: at any ratio other than 1:2 the `|' separators of a table
+    ;; containing Japanese drift further apart on every row.
+    "Monaco"
+    "Monaco Nerd Font Mono"
+    ;; Fallbacks for machines without Monaco.  These ship Japanese glyphs at
+    ;; exactly twice the half-width advance already, so they need no tuning.
     "HackGen Console NF"
     "HackGen35 Console NF"
     "HackGen"
@@ -26,20 +31,15 @@
     "PlemolJP Console NF"
     "PlemolJP"
     "Cica"
-    "Ricty Diminished"
-    ;; Fallbacks.  These are ASCII-only, so Japanese falls back to whatever
-    ;; the system picks (Hiragino on macOS) at an unrelated advance width;
-    ;; `my-tune-cjk-font' repairs the ratio as best it can in that case.
-    "Monaco Nerd Font Mono"
-    "Monaco")
+    "Ricty Diminished")
   "Font families for the default face, most preferred first.
 The first family that is actually installed wins, so an entry that is not
 present on this machine simply falls through to the next one.")
 
 (defvar my-cjk-fallback-font-candidates
-  '("HackGen" "UDEV Gothic" "PlemolJP" "Cica" "Ricty Diminished"
-    "Hiragino Sans" "Hiragino Kaku Gothic ProN"
-    "Noto Sans Mono CJK JP" "Noto Sans CJK JP" "IPAGothic")
+  '("Hiragino Sans" "Hiragino Kaku Gothic ProN"
+    "Noto Sans Mono CJK JP" "Noto Sans CJK JP" "IPAGothic"
+    "HackGen" "UDEV Gothic" "PlemolJP" "Cica" "Ricty Diminished")
   "Japanese families to pin when the default face font has no CJK glyphs.")
 
 (defun my-first-available-font (candidates)
@@ -69,50 +69,57 @@ Use this to verify the font setup instead of eyeballing a table."
       (message "Full/half width ratio is %.3f -- Org tables with Japanese line up."
                ratio))
      (t
-      (message "Full/half width ratio is %.3f (want 2.000) -- Org tables with Japanese will drift. Install e.g. %s"
-               ratio (car my-font-candidates))))))
+      (message "Full/half width ratio is %.3f (want 2.000) -- Org tables with Japanese will drift. Try M-x my-tune-cjk-font"
+               ratio)))))
 
-(defun my--set-font-rescale (family factor)
-  "Rescale FAMILY by FACTOR via `face-font-rescale-alist'.
-The alist is keyed by a regexp matched against the full font name, so the
-quoted family name is used as a substring pattern."
-  (let ((key (regexp-quote family)))
-    (setq face-font-rescale-alist
-          (cons (cons key factor)
-                (assoc-delete-all key face-font-rescale-alist)))))
+(defun my--set-cjk-font (family size)
+  "Render the CJK charsets with FAMILY at SIZE pixels."
+  (dolist (charset '(japanese-jisx0208 japanese-jisx0212
+                     katakana-jisx0201 kana han cjk-misc))
+    ;; ADD nil replaces the charset's entry outright, so re-running this
+    ;; (after `text-scale+', say) does not pile up stale sizes behind it.
+    (set-fontset-font t charset (font-spec :family family :size size)))
+  (clear-face-cache))
 
 (defun my-tune-cjk-font ()
-  "Correct the CJK/ASCII width ratio to 1:2 when the current font misses it.
-No-op when the ratio is already right, which is the case for every family
-at the head of `my-font-candidates'.  Otherwise the default family has no
-Japanese glyphs, Emacs is falling back to some other family whose advance
-width has no relation to the ASCII one, and this pins that fallback and
-scales it until a full-width character occupies two columns.  The scaling
-is only as exact as integer pixel rounding allows; installing a 1:2 family
-is the real fix."
+  "Make full-width characters render exactly twice as wide as half-width ones.
+A no-op for the 1:2 families listed in `my-font-candidates'.  It is Monaco
+-- the preferred family -- that needs this: Monaco carries no Japanese
+glyphs, so Japanese falls back to a family whose advance width has nothing
+to do with Monaco's, and Org tables containing Japanese drift apart.
+
+A full-width glyph advances by its em box, so pinning the fallback family
+to twice `frame-char-width' pixels makes it occupy exactly two columns.
+Rounding inside the font can miss by a pixel, hence the small search around
+that nominal size.
+
+Note the cost of keeping Monaco: Monaco advances only ~0.6 em, so twice
+that is ~1.2 em and the Japanese font ends up visibly larger than the ASCII
+one -- lines containing Japanese are taller than pure-ASCII lines.
+
+The pinned size is absolute, so this has to run again whenever the default
+face height changes; `text-scale+' and friends below do that."
   (interactive)
   (let ((ratio (my-cjk-font-width-ratio)))
-    (when (and ratio (> (abs (- ratio 2.0)) 0.02))
-      (let ((family (my-first-available-font my-cjk-fallback-font-candidates)))
+    (when (and ratio (> (abs (- ratio 2.0)) 0.001))
+      (let* ((family (my-first-available-font my-cjk-fallback-font-candidates))
+             (nominal (* 2 (frame-char-width))))
         (when family
-          (dolist (charset '(japanese-jisx0208 japanese-jisx0212
-                             katakana-jisx0201 kana han cjk-misc))
-            (set-fontset-font t charset (font-spec :family family) nil 'prepend))
-          ;; Measure with a neutral scale first, then apply the correction
-          ;; the measurement asks for.
-          (my--set-font-rescale family 1.0)
-          (clear-face-cache)
-          (let ((measured (my-cjk-font-width-ratio)))
-            (when (and measured (> measured 0))
-              (my--set-font-rescale family (/ 2.0 measured))
-              (clear-face-cache)))
-          ;; Pixel rounding can leave a residual error that no rescaling
-          ;; factor removes.  Say so once rather than letting the tables
-          ;; silently stay crooked.
-          (let ((final (my-cjk-font-width-ratio)))
-            (when (and final (> (abs (- final 2.0)) 0.02))
-              (message "Full/half width ratio is %.3f after rescaling %s; install e.g. %s (M-x my-check-cjk-font-ratio)"
-                       final family (car my-font-candidates)))))))))
+          (unless (catch 'aligned
+                    (dolist (size (list nominal (1- nominal) (1+ nominal)
+                                        (- nominal 2) (+ nominal 2)))
+                      (when (> size 0)
+                        (my--set-cjk-font family size)
+                        (let ((measured (my-cjk-font-width-ratio)))
+                          (when (and measured
+                                     (< (abs (- measured 2.0)) 0.001))
+                            (throw 'aligned t)))))
+                    nil)
+            ;; Nothing landed exactly.  Keep the nominal size, which is the
+            ;; closest, and say so rather than leaving tables quietly crooked.
+            (my--set-cjk-font family nominal)
+            (message "Could not align %s to twice the ASCII width (M-x my-check-cjk-font-ratio)"
+                     family)))))))
 
 (defun my-apply-default-font (family)
   "Apply FAMILY to the default face and seed `default-frame-alist'."
@@ -165,20 +172,26 @@ is the real fix."
   (my-setup-fonts))
 
 ;;; Text scale functions
+;; `my-tune-cjk-font' pins the Japanese font to an absolute pixel size, which
+;; cannot follow the ASCII font on its own -- re-run it after every change to
+;; the default face height or Org tables go crooked again at the new size.
 (defun text-scale+ ()
   "Increase the size of text of CURRENT-BUFFER."
   (interactive)
-  (set-face-attribute 'default nil :height (+ (face-attribute 'default :height) 10)))
+  (set-face-attribute 'default nil :height (+ (face-attribute 'default :height) 10))
+  (my-tune-cjk-font))
 
 (defun text-scale- ()
   "Decrease the size of text of CURRENT-BUFFER."
   (interactive)
-  (set-face-attribute 'default nil :height (- (face-attribute 'default :height) 10)))
+  (set-face-attribute 'default nil :height (- (face-attribute 'default :height) 10))
+  (my-tune-cjk-font))
 
 (defun text-scale0 ()
   "Reset the size of text of CURRENT-BUFFER."
   (interactive)
-  (set-face-attribute 'default nil :height my-default-face-height))
+  (set-face-attribute 'default nil :height my-default-face-height)
+  (my-tune-cjk-font))
 
 (global-set-key "\M-+" 'text-scale+)
 (global-set-key "\M--" 'text-scale-)


### PR DESCRIPTION
## Summary

Org tables containing Japanese did not line up: the `|` separators drifted further apart on every row.

`org-table-align` pads cells by `string-width`, which counts a full-width character as two columns. The default face was Monaco, which carries no Japanese glyphs, so Japanese fell back to Hiragino at an advance width unrelated to Monaco's — at any ratio other than 1:2 the padding computed from the file cannot match what is drawn.

Monaco stays (it reads better than the alternatives); the Japanese font is made to fit it instead. Wide tables also no longer get folded in half by line wrapping.

## Key Changes

### Font selection and CJK width (`init-ui.el`)

Everything below lives in `init-ui.el`.

- `my-font-candidates` — families for the default face, most preferred first, headed by Monaco / Monaco Nerd Font Mono. The 1:2 Japanese-capable families (HackGen, UDEV Gothic, PlemolJP, Cica, Ricty Diminished) sit below as fallbacks for machines without Monaco; they need no tuning at all, so moving one to the front is all it takes to switch.
- `my-tune-cjk-font` — pins the Japanese family (`my-cjk-fallback-font-candidates`) to an explicit pixel size of twice `frame-char-width`. A full-width glyph advances by its em box, so that size makes it occupy exactly two columns. A small search around the nominal size absorbs the font's own rounding; `face-font-rescale-alist` was tried first and could only land *near* 2.0, never on it.
- `my-cjk-font-width-ratio` / `my-check-cjk-font-ratio` — measure the rendered full-width/half-width ratio via `string-pixel-width`, so the setup is verified by number rather than by eye. `M-x my-check-cjk-font-ratio` should report `2.000`.
- `text-scale+` / `text-scale-` / `text-scale0` re-run the tuning: the pinned size is absolute and cannot follow the ASCII font on its own.
- `my-first-available-font` / `my-apply-default-font` / `my-setup-fonts` — the font work moves *out* of the two per-platform blocks and into `my-setup-fonts`, called once after them under `(when (display-graphic-p) …)`. The Darwin block stays, but only for what is genuinely macOS-specific: the key modifiers and the display-size-dependent `my-default-face-height`. The GNU/Linux block goes away entirely, and with it the TODO it carried — it used `set-frame-font`, which leaves the default face's `:family` unspecified, the exact condition that makes vertico-posframe child frames re-resolve to a proportional font.

### Line wrapping in Org (`init-org.el`)

One line: `visual-line-mode` is gone from `org-mode-hook`. It was overriding Org's own `org-startup-truncated`, which is what keeps a wide table row from being folded in the middle. `org-startup-truncated` is set explicitly in `:custom` — it is already Org's default, but it carries the rationale.

Intermediate commits on this branch tried a cursor-position toggle and then an explicit `truncate-lines` in the hook; both were dropped once it was clear the single removal is the whole fix. Emacs has no per-line `truncate-lines`, so wrapping is all-or-nothing per buffer and there is no toggle that leaves both the in-table and out-of-table states looking right.

### Documentation (`README.md`)

New "Fonts" section covering the 1:2 requirement, how the pinning works, and the trade-off below.

## Trade-off

Monaco advances only ~0.6 em, so twice that is ~1.2 em: the Japanese font ends up visibly larger than the ASCII one and lines containing Japanese are taller than pure-ASCII lines. That is the accepted cost of keeping Monaco. Long prose now runs off the right edge instead of wrapping; Org's built-in column shrinking (`C-c TAB`, `| <10> | <30> |` width cookies, `#+STARTUP: shrink`) is the complementary answer for tables too wide to scroll around comfortably.

## Verification

Table alignment, the taller-Japanese-lines trade-off, and the wrapping behaviour were checked interactively on macOS. Not re-checked since the last commit: `M-x my-check-cjk-font-ratio` reporting `2.000`, the ratio holding across `M-+` / `M--` / `M-0`, and the vertico-posframe / dired font fallback. The font and wrapping code is display-dependent, so no ERT tests were added; CI covers the byte-compile.

https://claude.ai/code/session_01LcsQ38bN2H3ENEsWcrrRgH