### PR TITLE
Fix the backup-each-save hook name

### DIFF
--- a/lisp/init-editor.el
+++ b/lisp/init-editor.el
@@ -353,7 +353,7 @@ if ENV-SH indicates a remote path. Relies on the helper function
   (setq backup-each-save-size-limit 5000000)
   ;; backup all the files
   (setq backup-each-save-filter-function 'identity)
-  :init (add-hook 'after-save #'backup-each-save)
+  :init (add-hook 'after-save-hook #'backup-each-save)
   )
 
 ;;; Buffer management


### PR DESCRIPTION
## Summary

`lisp/init-editor.el` registered `backup-each-save` on `after-save`, which is not a hook Emacs ever runs. The correct hook is `after-save-hook`, as the package's own Commentary documents.

`add-hook` defines the variable when it is unbound, so the typo raised no error and left a stray `after-save` variable behind. The result: `backup-each-save` never ran and no per-save backup was ever written.

The bug dates back to the initial commit; it is unrelated to any recent change.

## Verification

Confirmed the failure mode in batch Emacs:

```
boundp after-save: nil
after boundp: t value=(ignore)   ; add-hook creates a variable nothing reads
after-save-hook: nil             ; the real hook stays empty
```

Byte-compiling `lisp/init-editor.el` reports no new warnings. The ERT suite result is unchanged: 82/83 pass, and `review-model-format-time-should-format-iso` fails identically on unmodified `main` (it renders in the local zone, not the `TZ=UTC` the test intends).

## Note

With the hook fixed, every save now copies the file into `~/.emacs.d/backups`. That path resolves into this repository, but `.gitignore` already excludes `backups/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)