### PR TITLE
Require cl-lib instead of the obsolete cl

### DIFF
--- a/lisp/init-basic.el
+++ b/lisp/init-basic.el
@@ -7,7 +7,7 @@
 
 (require 'init-utils)
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 ;;; Enable repeat-mode so commands like C-x { can be repeated by pressing { again
 (repeat-mode 1)


### PR DESCRIPTION
## Emacs 31 removes the `cl` compatibility library

`lisp/init-basic.el` required `cl` at compile time. Emacs 31 drops that
library entirely, so byte-compiling the config on Emacs 31 will fail. The
rest of the repository already standardized on `cl-lib`
(`my-vterm-toggle.el`, `my-forge-ediff-review.el`,
`my-forge-ediff-review-model.el`), leaving this the last holdout.

## Swap the require for `cl-lib`

Note that `init-basic.el` calls no `cl` or `cl-lib` function today, so the
`eval-when-compile` block could be deleted outright. This change keeps the
minimal edit; removing the block is a reasonable follow-up.

## Verified by byte-compiling and running the test suite

- `emacs -batch -l init.el -f batch-byte-compile init.el` exits 0, matching
  the CI lint step.
- `emacs -Q --batch -L lisp -f batch-byte-compile lisp/init-basic.el` exits 0.
- The ERT suite reports 82 of 83 tests passing. The single failure,
  `review-model-format-time-should-format-iso`, also fails on `main` because
  the test expects UTC while the local timezone is PDT. It is unrelated to
  this change.

Generated with [Claude Code](https://claude.com/claude-code)