### PR TITLE
Drop the Emacs 22/23, Carbon and Meadow compatibility layer

### DIFF
--- a/lisp/init-utils.el
+++ b/lisp/init-utils.el
@@ -7,82 +7,9 @@
 
 ;;; System compatibility utilities
 
-(defun cocoa-emacs-p ()
-  (and (= emacs-major-version 23) (eq window-system 'ns)))
-
-(defun carbon-emacs-p ()
-  (and (= emacs-major-version 22) (eq window-system 'mac)))
-
-(defun meadowp ()
-  (eq system-type 'windows-nt))
-
-(defun cygwinp ()
-  (eq system-type 'cygwin))
-
-(defun emacs22p ()
-  (= emacs-major-version 22))
-
-(defun emacs23p ()
-  (= emacs-major-version 23))
-
-(defmacro when-gui (&rest bodies)
-  `(when window-system
-     ,@bodies))
-
-(defmacro when-meadow (&rest bodies)
-  `(when (meadowp)
-     ,@bodies))
-
 (defmacro when-darwin (&rest bodies)
+  "Evaluate BODIES only on macOS."
   `(when (eq system-type 'darwin)
-     ,@bodies))
-
-(defmacro when-cygwin (&rest bodies)
-  `(when (cygwinp)
-     ,@bodies))
-
-(defmacro when-carbon (&rest bodies)
-  `(when (carbon-emacs-p)
-     ,@bodies))
-
-(defmacro when-cocoa (&rest bodies)
-  `(when (cocoa-emacs-p)
-     ,@bodies))
-
-(defmacro when-emacs22 (&rest bodies)
-  `(when (emacs22p)
-     ,@bodies))
-
-(defmacro when-emacs23 (&rest bodies)
-  `(when (emacs23p)
-     ,@bodies))
-
-(defmacro unless-gui (&rest bodies)
-  `(unless window-system
-     ,@bodies))
-
-(defmacro unless-meadow (&rest bodies)
-  `(unless (meadowp)
-     ,@bodies))
-
-(defmacro unless-cygwin (&rest bodies)
-  `(unless (cygwinp)
-     ,@bodies))
-
-(defmacro unless-carbon (&rest bodies)
-  `(unless (carbon-emacs-p)
-     ,@bodies))
-
-(defmacro unless-cocoa (&rest bodies)
-  `(unless (cocoa-emacs-p)
-     ,@bodies))
-
-(defmacro unless-emacs22 (&rest bodies)
-  `(unless (emacs22p)
-     ,@bodies))
-
-(defmacro unless-emacs23 (&rest bodies)
-  `(unless (emacs23p)
      ,@bodies))
 
 (defun my-find-file-under-directories (file dirs)


### PR DESCRIPTION
`init-utils.el` opened with a compatibility layer for platforms this config has not run on in over a decade: six predicates (`cocoa-emacs-p`, `carbon-emacs-p`, `meadowp`, `cygwinp`, `emacs22p`, `emacs23p`) and fourteen `when-`/`unless-` macros built on top of them.

Emacs 22 and 23 shipped in 2007 and 2009, Carbon Emacs and Meadow are both long discontinued, and this config targets Emacs 30.

A grep across the whole repository finds exactly one call site for any of the twenty definitions:

```
lisp/init-ui.el:149:(when-darwin
```

So `when-darwin` stays (with a docstring added), and the other nineteen go — 74 lines removed.

Verified `lisp/init-utils.el` still reads cleanly with `emacs -Q --batch`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R25LxdubLRhjjwRmTRQqc3)_