### PR TITLE
Point open-setting-file at the init file that actually exists

### DIFF
--- a/lisp/init-utils.el
+++ b/lisp/init-utils.el
@@ -99,9 +99,9 @@ Returns non-nil if FILE is found in any of the directories in DIRS."
 ;;; File and buffer management
 
 (defun open-setting-file ()
-  "Open this file."
+  "Open the Emacs init file."
   (interactive)
-  (find-file "~/.emacs./lisp/garaemon-dot-emacs.el"))
+  (find-file (expand-file-name "init.el" user-emacs-directory)))
 
 (defun save-all ()
   "Save all buffers without y-or-n asking."


### PR DESCRIPTION
`open-setting-file` pointed at `~/.emacs./lisp/garaemon-dot-emacs.el` — a stray dot after `.emacs`, and a filename from the layout that predates the `init-*.el` split. Neither the directory nor the file exists, so `M-x open-setting-file` only ever opened an empty buffer for a nonexistent path.

```elisp
-  (find-file "~/.emacs./lisp/garaemon-dot-emacs.el"))
+  (find-file (expand-file-name "init.el" user-emacs-directory)))
```

Building the path from `user-emacs-directory` instead of hard-coding it also means the command follows a non-default `~/.emacs.d`. Targeting `user-emacs-directory` rather than `user-init-file` avoids landing on `init.elc` when a byte-compiled init is loaded — which the CI byte-compile step produces.

Docstring updated from "Open this file." to match.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R25LxdubLRhjjwRmTRQqc3)_