### PR TITLE
Drop the setq for yasnippet's removed yas-trigger-key

### DIFF
--- a/lisp/init-prog.el
+++ b/lisp/init-prog.el
@@ -1126,9 +1126,7 @@ Changes AFTER the selected commit are shown in the fringe (exclusive)."
   :config
   (setq yas-snippet-dirs '("~/.emacs.d/snippets"
                            "~/.emacs.d/yasnippet-snippets/snippets"))
-  (setq yas-trigger-key "Enter")
   (yas-global-mode 1)
-  ;;(custom-set-variables '(yas-trigger-key "TAB"))
 
   ;; insert new snippet
   (define-key yas-minor-mode-map (kbd "C-x i i") 'yas-insert-snippet)


### PR DESCRIPTION
yasnippet removed `yas-trigger-key` back in 0.8; expansion has been bound through `yas-maybe-expand` in `yas-minor-mode-map` ever since.

Setting it just defined a stray dynamic variable that yasnippet never reads, so the `"Enter"` value had no effect on the trigger key — and the value wasn't even a valid key description, which is a hint at how long it had been dead.

```elisp
-  (setq yas-trigger-key "Enter")
   (yas-global-mode 1)
-  ;;(custom-set-variables '(yas-trigger-key "TAB"))
```

The commented-out `custom-set-variables` line proposing `"TAB"` for the same dead variable goes with it.

No behavior change: the real bindings in this block (`C-x i i`, `C-x i n`, `C-x i v`) and yasnippet's own `TAB` → `yas-maybe-expand` are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R25LxdubLRhjjwRmTRQqc3)_