### PR TITLE
Drop 25 orphaned entries from package-selected-packages

### DIFF
--- a/init.el
+++ b/init.el
@@ -66,21 +66,18 @@
  ;; If there is more than one, they won't work right.
  '(minuet-auto-suggestion-block-predicates '(minuet-evil-not-insert-state-p my-not-eolp) nil nil "Customized with use-package minuet")
  '(package-selected-packages
-   '(aidermacs all-the-icons anzu apheleia auth-source-1password auto-highlight-symbol backup-each-save
-               base16-theme blamer bm browse-at-remote buffer-move buttercup calfw cape casual
-               clang-format cmake-mode coffee-mode corfu diff-hl docker dockerfile-mode elpy
-               embark-consult euslisp-mode expreg fill-column-indicator flycheck forge gcmh gist
-               git-auto-commit-mode go-mode google-c-style google-this gptel graphviz-dot-mode hiwin
-               hyde imenus jinja2-mode jinx json-mode lsp-sourcekit lsp-ui lua-mode marginalia
-               minuet modern-cpp-font-lock multi-vterm multiple-cursors nix-mode nlinum ob-mermaid
-               orderless org-ai org-download org-excalidraw org-faces org-modern org-roam outshine
-               persistent-scratch php-mode powerline projectile protobuf-mode puppet-mode py-yapf
-               qml-mode rainbow-delimiters recentf-ext rust-mode slack smart-cursor-color
-               smart-mode-line smartrep solarized-theme sqlite3 sr-speedbar string-inflection
-               swift-mode swiper switch-buffer-functions switch-window sx systemd terraform-mode
-               thingopt total-lines transpose-frame treemacs-magit treesit-auto trr tsx-mode
-               typescript-mode udev-mode undo-tree vertico-posframe volatile-highlights vterm-toggle
-               vundo window-purpose yaml-mode yasnippet-capf yatemplate))
+   '(all-the-icons anzu apheleia auth-source-1password auto-highlight-symbol backup-each-save
+               base16-theme bm browse-at-remote buffer-move calfw cape clang-format cmake-mode
+               coffee-mode corfu diff-hl docker dockerfile-mode elpy embark-consult expreg
+               fill-column-indicator flycheck forge gist go-mode google-c-style google-this gptel
+               graphviz-dot-mode imenus jinja2-mode jinx json-mode lsp-sourcekit lsp-ui lua-mode
+               marginalia minuet modern-cpp-font-lock multi-vterm multiple-cursors nix-mode
+               ob-mermaid orderless org-ai org-download org-excalidraw org-modern org-roam outshine
+               php-mode projectile protobuf-mode puppet-mode py-yapf qml-mode recentf-ext rust-mode
+               smartrep solarized-theme sqlite3 string-inflection swift-mode swiper switch-window
+               systemd terraform-mode thingopt treemacs-magit treesit-auto tsx-mode typescript-mode
+               udev-mode undo-tree vertico-posframe vterm-toggle vundo yaml-mode yasnippet-capf
+               yatemplate))
  '(package-vc-selected-packages
    '((org-excalidraw :url "https://github.com/4honor/org-excalidraw.git"))))
 (custom-set-faces


### PR DESCRIPTION
`package-selected-packages` had drifted into a graveyard. 25 of its 107 entries are not referenced anywhere else in the repository — no `use-package` form, no `require`, no hook, no mention in the README — yet they are still installed by `package-install-selected-packages` and still weighed on every upgrade.

Several are superseded by what the config actually loads now:

- `nlinum` → `display-line-numbers` (built in since Emacs 26)
- `powerline`, `smart-mode-line` → the modeline setup in `init-ui.el`
- `sr-speedbar` → `treemacs`

Removed:

`aidermacs`, `blamer`, `buttercup`, `casual`, `euslisp-mode`, `gcmh`, `git-auto-commit-mode`, `hiwin`, `hyde`, `nlinum`, `org-faces`, `persistent-scratch`, `powerline`, `rainbow-delimiters`, `slack`, `smart-cursor-color`, `smart-mode-line`, `sr-speedbar`, `switch-buffer-functions`, `sx`, `total-lines`, `transpose-frame`, `trr`, `volatile-highlights`, `window-purpose`

Two notes on the method:

- `org-faces` is a file inside org itself and was never a package on any archive.
- `nlinum`'s only hit outside the list is the word `nlinum-mode` inside a comment in `my-forge-ediff-review.el`, not a use.

The remaining 82 entries all have a live reference. `elpy` and `py-yapf` are kept because their `use-package` forms still exist (disabled via `:if nil`).

Verified `init.el` still reads cleanly with `emacs -Q --batch`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R25LxdubLRhjjwRmTRQqc3)_