### PR TITLE
Strip the dead flymake and pbcopy blocks from garaemon-objective-c.el

### DIFF
--- a/lisp/garaemon-objective-c.el
+++ b/lisp/garaemon-objective-c.el
@@ -1,46 +1,11 @@
-;; -*- mode: emacs-lisp -*-
-(setq auto-mode-alist
-      (append auto-mode-alist '(("\\.h$" . objc-mode)
-                                ("\\.m$" . objc-mode))))
+;;; garaemon-objective-c.el --- Objective-C and Xcode helpers -*- lexical-binding: t -*-
 
-;; (require 'flymake)
+;;; Commentary:
+;; Objective-C mode setup plus small wrappers around the xcode-*.sh scripts.
+;; Not loaded by init.el; require it explicitly when doing iOS work.
 
-;; (defvar flymake-compiler "gcc")
-;; (defvar flymake-compile-options nil)
-;; (defvar flymake-compile-default-options
-;;         (list "-Wall" "-Wextra" "-fsyntax-only"))
+;;; Code:
 
-;; (defun flymake-objc-init ()
-;;   (let* ((temp-file   (flymake-init-create-temp-buffer-copy
-;;                        'flymake-create-temp-inplace))
-;;          (local-file  (file-relative-name
-;;                        temp-file
-;;                        (file-name-directory buffer-file-name)))
-;; 	 (options flymake-compile-default-options))
-;;     (list flymake-compiler (append options (list local-file)))))
-
-;; (push '("\\.m$" flymake-objc-init) flymake-allowed-file-name-masks)
-;; (push '("\\.h$" flymake-objc-init) flymake-allowed-file-name-masks)
-
-;; (add-hook 'objc-mode-hook
-;;           '(lambda ()
-;; 	     (flymake-mode t)))
-
-;;(provide 'flymake-objc)
-
-;; clipboard
-;; (if (not window-system)
-;;     (progn
-;;       (defun copy-from-osx ()
-;;         (shell-command-to-string "pbpaste"))
-;;       (defun paste-to-osx (text &optional push)
-;;         (let ((process-connection-type nil))
-;;           (let ((proc (start-process "pbcopy" "*Messages*" "pbcopy")))
-;;             (process-send-string proc text)
-;;             (process-send-eof proc))))
-;;       (setq interprogram-cut-function 'paste-to-osx)
-;;       (setq interprogram-paste-function 'copy-from-osx)))
-;; objc, Xcode
 (setq auto-mode-alist (append (list '("\\.h$" . objc-mode)
                                     '("\\.m$" . objc-mode))
                               auto-mode-alist))
@@ -54,7 +19,6 @@
               (define-key objc-mode-map "\C-cc"    'uncomment-region)
               (setq compile-command
                     "xcodebuild -project ../*.xcodeproj -configuration Debug -sdk iphonesimulator5.0 ")
-              ;;"xcodebuild -project ../*.xcodeproj -configuration Debug -sdk iphonesimulator4.3 ")
               (setq compilation-scroll-output t)))
 
 (defun doc ()
@@ -69,3 +33,4 @@
   (interactive)
   (shell-command-to-string "/usr/local/bin/xcode-run.sh"))
 (provide 'garaemon-objective-c)
+;;; garaemon-objective-c.el ends here


### PR DESCRIPTION
Roughly half of this 71-line file was commented out:

- A `flymake-objc-init` backend written against the pre-26 flymake API (`flymake-allowed-file-name-masks`, `flymake-init-create-temp-buffer-copy`, `flymake-compiler` = `gcc`). That API was replaced wholesale in Emacs 26, so this would not work even if uncommented.
- A `copy-from-osx` / `paste-to-osx` clipboard bridge shelling out to `pbcopy`/`pbpaste`, which macOS Emacs has not needed for years.

Also dropped a duplicate `auto-mode-alist` `setq` — the top of the file and the middle both registered `objc-mode` for `.h` and `.m` with identical entries — and a commented-out alternate `compile-command` for the iOS 4.3 simulator.

While here, added the missing file header, `lexical-binding` cookie and `ends-here` footer.

**Worth knowing:** `init.el` never requires this file. It only takes effect if loaded by hand, which the new commentary now says. I kept the live code (objc mode hook, the `xcode-*.sh` wrappers) rather than deleting the file, since the ask was to remove the dead flymake code — say the word if you'd rather retire the whole thing.

71 → 35 lines. Verified it still reads cleanly with `emacs -Q --batch`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R25LxdubLRhjjwRmTRQqc3)_