### PR TITLE
Point the README badge at the workflow it reports on

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# emacs.d [![Build Status](https://github.com/garaemon/emacs.d/actions/workflows/test.yml/badge.svg)](https://github.com/garaemon/emacs.d/actions?query=workflow%3Alint)
+# emacs.d [![Build Status](https://github.com/garaemon/emacs.d/actions/workflows/test.yml/badge.svg)](https://github.com/garaemon/emacs.d/actions/workflows/test.yml)
 
 my private emacs setting
 


### PR DESCRIPTION
The badge image came from `test.yml` but its link went to `actions?query=workflow%3Alint`. There is no `lint` workflow — `.github/workflows/` holds only `test.yml` (`name: Test Emacs Lisp`) — so clicking a green badge landed on an empty filtered run list.

```diff
-...badge.svg)](https://github.com/garaemon/emacs.d/actions?query=workflow%3Alint)
+...badge.svg)](https://github.com/garaemon/emacs.d/actions/workflows/test.yml)
```

Linking straight to the workflow page rather than a name query also keeps image and link in sync if the workflow is ever renamed — the query form breaks on rename, the file path doesn't.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R25LxdubLRhjjwRmTRQqc3)_