### PR TITLE
P0.1: Show the PR's conversation comments in the review buffer

### DIFF
--- a/lisp/my-forge-ediff-review-model.el
+++ b/lisp/my-forge-ediff-review-model.el
@@ -214,12 +214,55 @@ as \"(no description)\" so the buffer never looks broken or truncated."
               body
             "(no description)")))
 
+(defun my-forge-ediff-review-model--format-comment (comment)
+  "Return the markdown section for one conversation COMMENT.
+COMMENT is a plist (:author :body :created-at).  The body is emitted
+verbatim, only stripped of trailing blank lines, so that whatever
+markdown the author wrote still renders."
+  (let ((author (or (plist-get comment :author) "unknown"))
+        (time (my-forge-ediff-review-model-format-time
+               (plist-get comment :created-at)))
+        (body (or (plist-get comment :body) "")))
+    (concat "\n### " author
+            (if (string-empty-p time) "" (concat " \u2014 " time))
+            "\n\n"
+            (if (string-empty-p (string-trim body))
+                "(empty comment)"
+              (string-trim-right body))
+            "\n")))
+
+(defun my-forge-ediff-review-model-format-conversation
+    (num title body comments)
+  "Return the markdown text of PR NUM's conversation, titled TITLE.
+BODY is the PR description and COMMENTS the list of plists from
+`my-forge-ediff-review-model-parse-conversation', oldest first.  The
+header reuses `my-forge-ediff-review-model-format-description' so the
+description buffer's opening is unchanged.  Comment bodies are laid out
+as plain markdown sections rather than the box-drawn cards used for
+inline overlays: a box would re-wrap the text to a fixed width and break
+the code blocks, lists and quotes people write in PR discussions."
+  (concat
+   (my-forge-ediff-review-model-format-description num title body)
+   "\n"
+   (if (null comments)
+       "## Comments\n\nNo comments yet.\n"
+     (concat
+      (format "## Comments (%d)\n" (length comments))
+      (mapconcat #'my-forge-ediff-review-model--format-comment comments "")))
+   (format "\n-- PR #%s \u00b7 g to refresh --\n" num)))
+
 (defun my-forge-ediff-review-model-format-time (iso)
   "Return a short local-time string for GitHub ISO8601 timestamp ISO.
 ISO looks like \"2026-01-15T10:30:00Z\".  A nil or empty ISO yields the
-empty string so callers can omit the time without extra whitespace."
+empty string so callers can omit the time without extra whitespace.  An
+unparsable ISO yields the empty string too, rather than signalling: a
+timestamp is decoration, and a single odd value coming from forge's
+local database must not abort the rendering of a whole buffer."
   (if (and (stringp iso) (not (string-empty-p iso)))
-      (format-time-string "%Y-%m-%d %H:%M" (encode-time (iso8601-parse iso)))
+      (condition-case nil
+          (format-time-string "%Y-%m-%d %H:%M"
+                              (encode-time (iso8601-parse iso)))
+        (error ""))
     ""))
 
 ;;;; GitHub review payload
@@ -296,6 +339,37 @@ entries keep their thread/comment order."
                           :resolved resolved
                           :thread-id thread-id :reply-to-id reply-to-id)
                     entries))))))))
+
+;;;; Conversation comments (parsed from GitHub GraphQL)
+
+(defun my-forge-ediff-review-model-parse-conversation (response)
+  "Parse a GitHub pull-request comments GraphQL RESPONSE into comment plists.
+Each entry is a plist (:id :author :body :created-at :url) describing one
+conversation-tab comment, kept in the order GitHub returned them, which
+is oldest first.  These are `IssueComment' objects -- the PR-level
+discussion -- and not the inline review comments handled by
+`my-forge-ediff-review-model-parse-review-threads'.  A comment whose
+author was deleted carries no `author' object, so :author falls back to
+\"unknown\" instead of rendering an empty byline."
+  (let* ((data (my-forge-ediff-review-model--response-data response))
+         (pullreq (alist-get 'pullRequest (alist-get 'repository data))))
+    (mapcar
+     (lambda (comment)
+       (list :id (alist-get 'id comment)
+             :author (or (alist-get 'login (alist-get 'author comment))
+                         "unknown")
+             :body (alist-get 'body comment)
+             :created-at (alist-get 'createdAt comment)
+             :url (alist-get 'url comment)))
+     (my-forge-ediff-review-model--graphql-nodes pullreq 'comments))))
+
+(defun my-forge-ediff-review-model-parse-pr-node-id (response)
+  "Return the pull request's GraphQL node id from RESPONSE, or nil.
+The node id is what GitHub's GraphQL mutations take as `pullRequestId',
+so it is worth keeping once the conversation query has fetched it."
+  (let* ((data (my-forge-ediff-review-model--response-data response))
+         (pullreq (alist-get 'pullRequest (alist-get 'repository data))))
+    (alist-get 'id pullreq)))
 
 ;;;; API host resolution
 

--- a/lisp/my-forge-ediff-review.el
+++ b/lisp/my-forge-ediff-review.el
@@ -12,7 +12,7 @@
 ;;
 ;;     (:owner "..." :repo "..." :num N :title "..." :body "..."
 ;;      :base-rev "<sha>" :head-rev "<sha>" :host nil
-;;      :comments (COMMENT ...))
+;;      :comments (COMMENT ...) :conversation (POST ...))
 ;;
 ;;   Each pending comment is itself a plist:
 ;;
@@ -39,6 +39,10 @@
 ;;   3. `my-forge-ediff-review-list-comments' shows pending comments.
 ;;   4. `my-forge-ediff-review-submit' POSTs them all as one review via
 ;;      ghub against /repos/<owner>/<repo>/pulls/<num>/reviews.
+;;   5. `my-forge-ediff-review-show-conversation' shows the PR description
+;;      followed by its discussion comments -- GitHub's Conversation tab.
+;;      It opens from forge's local database and refreshes over GraphQL,
+;;      so it is readable offline and current when online.
 
 ;;; Code:
 
@@ -50,7 +54,8 @@
 (defvar my-forge-ediff-review--session nil
   "Plist for the active review session, or nil.
 Keys: :owner :repo :num :title :body :head-rev :base-rev :host
-:comments :memos :reviewed :existing :commits.  :title and :body are the
+:comments :memos :reviewed :existing :commits :conversation
+:pr-node-id.  :title and :body are the
 PR's title and description, read from forge's local database so they can
 be shown while reviewing.  Each comment and memo is a plist with :path
 :line :side :body; memos stay local and are never submitted.  :reviewed
@@ -58,7 +63,12 @@ is a list of repository-relative file paths the user has flagged as
 done.  :existing holds review comments already posted to the PR on
 GitHub, fetched once at session start and shown read-only as overlays.
 :commits is the PR's commit history, oldest first, read once from local
-git at session start; each commit is a plist (:hash :subject).")
+git at session start; each commit is a plist (:hash :subject).
+:conversation holds the PR-level discussion comments, seeded from
+forge's local database at session start and refreshed from GitHub when
+the conversation buffer is opened; each is a plist (:id :author :body
+:created-at :url).  :pr-node-id is the PR's GraphQL node id, learned
+from that same fetch and needed by GraphQL mutations.")
 
 (defvar my-forge-ediff-review--cards-collapsed nil
   "When non-nil, inline comment cards render as one-line summaries.
@@ -159,7 +169,10 @@ launches multi-file ediff between PR base and head."
                   :reviewed nil
                   :existing nil
                   :commits (my-forge-ediff-review--pr-commits
-                            diff-base head-rev)))
+                            diff-base head-rev)
+                  :conversation (my-forge-ediff-review--posts-from-forge
+                                 pullreq)
+                  :pr-node-id nil))
       ;; Start every review with cards unfolded; the fold flag is global,
       ;; so without this a stray `c' in an earlier review would leave this
       ;; one showing only one-line summaries.
@@ -186,33 +199,137 @@ forges resolve to nil so ghub falls back to its default host."
   (unless my-forge-ediff-review--session
     (user-error "No active forge ediff review session")))
 
-;;;; PR description
+;;;; PR conversation (description and discussion comments)
 
-(defconst my-forge-ediff-review--description-buffer-name
-  "*forge-review-description*"
-  "Name of the read-only buffer showing the PR title and description.")
+(defconst my-forge-ediff-review--conversation-buffer-name
+  "*forge-review-conversation*"
+  "Name of the read-only buffer showing the PR description and comments.")
 
-(defun my-forge-ediff-review-show-description ()
-  "Show the PR's title and description in a read-only markdown buffer.
-Available from the revision buffers and the sidebar on `D'; the buffer
-closes with `q' (via `view-mode')."
-  (interactive)
-  (my-forge-ediff-review--ensure-session)
+(defvar my-forge-ediff-review-conversation-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "g") #'my-forge-ediff-review-show-conversation)
+    (define-key map (kbd "q") #'quit-window)
+    map)
+  "Keys composed over the conversation buffer's major mode.")
+
+(defvar-local my-forge-ediff-review--conversation-ready nil
+  "Non-nil once the conversation buffer's mode and keys are installed.
+Guards the one-time setup so that refreshing does not compose another
+copy of the keymap over the previous one on every `g'.")
+
+(defun my-forge-ediff-review--posts-from-forge (pullreq)
+  "Return PULLREQ's conversation comments from forge's local database.
+Forge already caches the PR-level discussion as `forge-pullreq-post'
+objects, so seeding from it lets the conversation buffer show something
+the moment it opens instead of waiting on the network -- and keeps it
+readable with no network at all.  The plists match the shape produced by
+`my-forge-ediff-review-model-parse-conversation', so the GraphQL refresh
+can replace them wholesale.  Any failure, such as a forge too old to
+carry the slot, yields nil and leaves the buffer to that refresh."
+  (ignore-errors
+    (mapcar (lambda (post)
+              (list :id (oref post id)
+                    :author (or (oref post author) "unknown")
+                    :body (oref post body)
+                    :created-at (oref post created)
+                    :url nil))
+            (oref pullreq posts))))
+
+(defconst my-forge-ediff-review--conversation-query
+  "query($owner:String!,$repo:String!,$number:Int!){
+     repository(owner:$owner,name:$repo){
+       pullRequest(number:$number){
+         id
+         comments(first:100){
+           nodes{ id databaseId body createdAt author{login} url }
+         }
+       }
+     }
+   }"
+  "GraphQL query fetching a PR's conversation comments and its node id.
+Only the first 100 comments come back; following the cursor past that is
+a separate roadmap item, so a very long discussion is silently short.")
+
+(defun my-forge-ediff-review--fetch-conversation ()
+  "Fetch the PR's conversation comments and refresh the buffer when they land.
+Runs asynchronously; a failure is reported but changes nothing, leaving
+whatever forge's local database seeded on screen."
+  (let* ((s my-forge-ediff-review--session)
+         (num (plist-get s :num)))
+    (when (fboundp 'ghub-query)
+      (ghub-query
+        my-forge-ediff-review--conversation-query
+        `((owner . ,(plist-get s :owner))
+          (repo . ,(plist-get s :repo))
+          (number . ,num))
+        :auth 'forge
+        :host (plist-get s :host)
+        :callback (lambda (response &rest _)
+                    (my-forge-ediff-review--on-conversation-fetched
+                     response num))
+        :errorback (lambda (err &rest _)
+                     (message "Could not fetch PR comments: %S" err))))))
+
+(defun my-forge-ediff-review--on-conversation-fetched (response num)
+  "Store conversation RESPONSE for PR NUM and redraw the buffer.
+NUM is the pull request the request was issued for.  A reply can outlive
+its session -- the reviewer quits and starts on a different PR while it
+is still in flight -- and without this check one PR's discussion would
+appear under another PR's title."
+  (when (and my-forge-ediff-review--session
+             (equal num (plist-get my-forge-ediff-review--session :num)))
+    (setf (plist-get my-forge-ediff-review--session :conversation)
+          (my-forge-ediff-review-model-parse-conversation response))
+    (setf (plist-get my-forge-ediff-review--session :pr-node-id)
+          (my-forge-ediff-review-model-parse-pr-node-id response))
+    ;; Redraw only if the buffer is around; never display it, since this
+    ;; runs asynchronously and stealing the window mid-review is rude.
+    (when (get-buffer my-forge-ediff-review--conversation-buffer-name)
+      (my-forge-ediff-review--render-conversation))))
+
+(defun my-forge-ediff-review--render-conversation ()
+  "Fill the conversation buffer from the session and return it.
+Does not display the buffer: an asynchronous refresh calls this too.
+Point is preserved so that refresh does not pull a reader back to the
+top of a discussion they are part-way through."
   (let ((s my-forge-ediff-review--session)
         (buf (get-buffer-create
-              my-forge-ediff-review--description-buffer-name)))
+              my-forge-ediff-review--conversation-buffer-name)))
     (with-current-buffer buf
-      (let ((inhibit-read-only t))
+      (unless my-forge-ediff-review--conversation-ready
+        (when (fboundp 'markdown-mode)
+          (markdown-mode))
+        ;; Compose over the major mode rather than calling `local-set-key',
+        ;; which would bind `g' in every markdown buffer by mutating the
+        ;; keymap they all share.
+        (use-local-map
+         (make-composed-keymap my-forge-ediff-review-conversation-mode-map
+                               (current-local-map)))
+        (setq-local my-forge-ediff-review--conversation-ready t))
+      (let ((inhibit-read-only t)
+            (pos (point)))
         (erase-buffer)
-        (insert (my-forge-ediff-review-model-format-description
+        (insert (my-forge-ediff-review-model-format-conversation
                  (plist-get s :num)
                  (plist-get s :title)
-                 (plist-get s :body))))
-      (when (fboundp 'markdown-mode)
-        (markdown-mode))
-      (view-mode 1)
-      (goto-char (point-min)))
-    (pop-to-buffer buf)))
+                 (plist-get s :body)
+                 (plist-get s :conversation)))
+        (goto-char (min pos (point-max))))
+      (setq buffer-read-only t))
+    buf))
+
+(defun my-forge-ediff-review-show-conversation ()
+  "Show the PR's description and discussion comments in a markdown buffer.
+Available from the revision buffers and the sidebar on `D'.  The buffer
+opens at once with the comments forge already cached locally and is
+refreshed from GitHub in the background; `g' refetches, `q' buries it."
+  (interactive)
+  (my-forge-ediff-review--ensure-session)
+  (pop-to-buffer (my-forge-ediff-review--render-conversation))
+  (my-forge-ediff-review--fetch-conversation))
+
+(define-obsolete-function-alias 'my-forge-ediff-review-show-description
+  #'my-forge-ediff-review-show-conversation "2026-08-07")
 
 ;;;; Existing review comments (fetched from GitHub)
 
@@ -459,7 +576,7 @@ file/rev locals set by `my-magit-ediff--create-revision-buffer'."
       (define-key map (kbd "r") #'my-forge-ediff-review-reply-to-comment)
       (define-key map (kbd "R") #'my-forge-ediff-review-toggle-resolved)
       (define-key map (kbd "d") #'my-forge-ediff-review-toggle-reviewed)
-      (define-key map (kbd "D") #'my-forge-ediff-review-show-description)
+      (define-key map (kbd "D") #'my-forge-ediff-review-show-conversation)
       (define-key map (kbd "c") #'my-forge-ediff-review-toggle-cards)
       (define-key map (kbd "n") #'my-forge-ediff-review-next-diff)
       (define-key map (kbd "p") #'my-forge-ediff-review-prev-diff)
@@ -928,7 +1045,7 @@ C-c C-c submits, C-c C-k cancels. HTML comments are stripped. -->\n\n"
     (define-key map (kbd "RET") #'my-forge-ediff-review-sidebar-open)
     (define-key map (kbd "<mouse-1>") #'my-forge-ediff-review-sidebar-open)
     (define-key map (kbd "d") #'my-forge-ediff-review-sidebar-toggle-reviewed)
-    (define-key map (kbd "D") #'my-forge-ediff-review-show-description)
+    (define-key map (kbd "D") #'my-forge-ediff-review-show-conversation)
     (define-key map (kbd "g") #'my-forge-ediff-review-sidebar-refresh)
     (define-key map (kbd "n") #'next-line)
     (define-key map (kbd "p") #'previous-line)

--- a/tests/my-forge-ediff-review-model-test.el
+++ b/tests/my-forge-ediff-review-model-test.el
@@ -336,6 +336,11 @@ LOCATION is an alist providing the thread-level `path', `line',
   (should (equal "" (my-forge-ediff-review-model-format-time nil)))
   (should (equal "" (my-forge-ediff-review-model-format-time ""))))
 
+(ert-deftest review-model-format-time-should-be-empty-for-garbage ()
+  "An unparsable timestamp must not abort the render of a whole buffer."
+  (should (equal "" (my-forge-ediff-review-model-format-time "not a date")))
+  (should (equal "" (my-forge-ediff-review-model-format-time "2026-13-45"))))
+
 ;;;; Card text padding and wrapping
 
 (ert-deftest review-model-pad-should-fill-to-width ()
@@ -492,6 +497,122 @@ LOCATION is an alist providing the thread-level `path', `line',
 
 (ert-deftest review-model-resolve-host-should-return-nil-when-empty ()
   (should-not (my-forge-ediff-review-model-resolve-host "")))
+
+;;;; Conversation comments (GitHub GraphQL response)
+
+(defun my-forge-ediff-review-model-test--conversation-response
+    (comment-nodes &optional node-id)
+  "Wrap COMMENT-NODES and NODE-ID in the pullRequest GraphQL envelope."
+  `((data
+     (repository
+      (pullRequest
+       ,@(when node-id `((id . ,node-id)))
+       (comments
+        (nodes . ,comment-nodes)))))))
+
+(defun my-forge-ediff-review-model-test--post (body author &optional created-at)
+  "Build one conversation comment node from BODY, AUTHOR login, CREATED-AT."
+  `((id . "IC_1")
+    (body . ,body)
+    ,@(when created-at `((createdAt . ,created-at)))
+    (url . "https://github.com/o/r/pull/1#issuecomment-1")
+    (author (login . ,author))))
+
+(ert-deftest review-model-conversation-should-parse-comments-in-order ()
+  (let ((posts (my-forge-ediff-review-model-parse-conversation
+                (my-forge-ediff-review-model-test--conversation-response
+                 (list (my-forge-ediff-review-model-test--post
+                        "first" "alice" "2026-01-15T10:30:00Z")
+                       (my-forge-ediff-review-model-test--post
+                        "second" "bob"))))))
+    (should (= 2 (length posts)))
+    (should (equal "first" (plist-get (car posts) :body)))
+    (should (equal "alice" (plist-get (car posts) :author)))
+    (should (equal "2026-01-15T10:30:00Z"
+                   (plist-get (car posts) :created-at)))
+    (should (equal "second" (plist-get (cadr posts) :body)))
+    (should (equal "bob" (plist-get (cadr posts) :author)))))
+
+(ert-deftest review-model-conversation-should-name-deleted-author-unknown ()
+  "A comment whose author was deleted has no `author' object at all."
+  (let ((posts (my-forge-ediff-review-model-parse-conversation
+                (my-forge-ediff-review-model-test--conversation-response
+                 '(((id . "IC_1") (body . "orphan")))))))
+    (should (equal "unknown" (plist-get (car posts) :author)))))
+
+(ert-deftest review-model-conversation-should-accept-vector-nodes ()
+  "Some JSON readers hand back vectors rather than lists."
+  (let ((posts (my-forge-ediff-review-model-parse-conversation
+                (my-forge-ediff-review-model-test--conversation-response
+                 (vector (my-forge-ediff-review-model-test--post
+                          "vectored" "alice"))))))
+    (should (= 1 (length posts)))
+    (should (equal "vectored" (plist-get (car posts) :body)))))
+
+(ert-deftest review-model-conversation-should-return-empty-for-no-comments ()
+  (should-not (my-forge-ediff-review-model-parse-conversation
+               (my-forge-ediff-review-model-test--conversation-response nil))))
+
+(ert-deftest review-model-conversation-should-parse-pr-node-id ()
+  (should (equal "PR_kwABC"
+                 (my-forge-ediff-review-model-parse-pr-node-id
+                  (my-forge-ediff-review-model-test--conversation-response
+                   nil "PR_kwABC")))))
+
+(ert-deftest review-model-conversation-node-id-should-be-nil-when-absent ()
+  (should-not (my-forge-ediff-review-model-parse-pr-node-id
+               (my-forge-ediff-review-model-test--conversation-response nil))))
+
+;;;; Conversation formatting
+
+(ert-deftest review-model-format-conversation-should-follow-the-description ()
+  "The PR body is rendered first, then the comments beneath it."
+  (let* ((process-environment (cons "TZ=UTC" process-environment))
+         (text (my-forge-ediff-review-model-format-conversation
+                7 "Title" "Body."
+                (list (list :author "alice" :body "Looks good."
+                            :created-at "2026-01-15T10:30:00Z")))))
+    (should (string-prefix-p "# PR #7: Title\n\nBody.\n" text))
+    (should (string-match-p "^## Comments (1)$" text))
+    (should (string-match-p "^### alice — 2026-01-15 10:30$" text))
+    (should (string-match-p "^Looks good\\.$" text))))
+
+(ert-deftest review-model-format-conversation-should-keep-comment-order ()
+  (let ((text (my-forge-ediff-review-model-format-conversation
+               7 "Title" "Body."
+               (list (list :author "alice" :body "first")
+                     (list :author "bob" :body "second")))))
+    (should (< (string-match "### alice" text)
+               (string-match "### bob" text)))))
+
+(ert-deftest review-model-format-conversation-should-say-when-empty ()
+  (let ((text (my-forge-ediff-review-model-format-conversation
+               7 "Title" "Body." nil)))
+    (should (string-match-p "No comments yet\\." text))
+    (should-not (string-match-p "###" text))))
+
+(ert-deftest review-model-format-conversation-should-not-wrap-bodies ()
+  "Bodies stay verbatim so markdown code blocks and lists survive."
+  (let* ((body (concat "Try this:\n\n```elisp\n(message \"hi\")\n```\n\n"
+                       "- one\n- two"))
+         (text (my-forge-ediff-review-model-format-conversation
+                7 "Title" "Body."
+                (list (list :author "alice" :body body)))))
+    (should (string-match-p "(message \"hi\")" text))
+    (should (string-match-p "^- one$" text))))
+
+(ert-deftest review-model-format-conversation-should-mark-an-empty-body ()
+  (let ((text (my-forge-ediff-review-model-format-conversation
+               7 "Title" "Body."
+               (list (list :author "alice" :body "   ")))))
+    (should (string-match-p "(empty comment)" text))))
+
+(ert-deftest review-model-format-conversation-should-omit-a-missing-time ()
+  "A comment with no timestamp gets a byline without a trailing dash."
+  (let ((text (my-forge-ediff-review-model-format-conversation
+               7 "Title" "Body."
+               (list (list :author "alice" :body "hi")))))
+    (should (string-match-p "^### alice$" text))))
 
 (provide 'my-forge-ediff-review-model-test)
 ;;; my-forge-ediff-review-model-test.el ends here

--- a/tests/my-forge-ediff-review-test.el
+++ b/tests/my-forge-ediff-review-test.el
@@ -128,5 +128,98 @@
                                                 (my-forge-ediff-review--dim-diff-faces)
                                                 (should-not (assq 'ediff-current-diff-A face-remapping-alist))))))
 
+;;;; Conversation buffer
+
+(defmacro my-forge-ediff-review-test--with-conversation (session &rest body)
+  "Run BODY with SESSION active and the conversation buffer killed after.
+The buffer is global and named, so leaving it behind would leak its mode
+and point into the next test."
+  (declare (indent 1))
+  `(let ((my-forge-ediff-review--session ,session))
+     (unwind-protect
+         (progn ,@body)
+       (let ((buf (get-buffer
+                   my-forge-ediff-review--conversation-buffer-name)))
+         (when (buffer-live-p buf)
+           (kill-buffer buf))))))
+
+(defun my-forge-ediff-review-test--conversation-session (&optional comments)
+  "Return a minimal session plist carrying COMMENTS as the conversation."
+  (list :num 42 :title "A title" :body "A body."
+        :conversation comments :pr-node-id nil))
+
+(ert-deftest my-forge-ediff-review-conversation-renders-description-and-comments ()
+  "The buffer shows the PR body first, then each comment."
+  (skip-unless my-forge-ediff-review-test--available)
+  (my-forge-ediff-review-test--with-conversation
+      (my-forge-ediff-review-test--conversation-session
+       (list (list :author "alice" :body "Looks good.")))
+    (with-current-buffer (my-forge-ediff-review--render-conversation)
+      (should (string-prefix-p "# PR #42: A title" (buffer-string)))
+      (should (string-match-p "### alice" (buffer-string)))
+      (should (string-match-p "Looks good\\." (buffer-string))))))
+
+(ert-deftest my-forge-ediff-review-conversation-buffer-is-read-only ()
+  "The buffer must not be editable, and `g'/`q' must reach our commands."
+  (skip-unless my-forge-ediff-review-test--available)
+  (my-forge-ediff-review-test--with-conversation
+      (my-forge-ediff-review-test--conversation-session)
+    (with-current-buffer (my-forge-ediff-review--render-conversation)
+      (should buffer-read-only)
+      (should (eq (key-binding (kbd "g"))
+                  #'my-forge-ediff-review-show-conversation))
+      (should (eq (key-binding (kbd "q")) #'quit-window)))))
+
+(ert-deftest my-forge-ediff-review-conversation-refresh-keeps-point ()
+  "A background refresh must not yank the reader back to the top."
+  (skip-unless my-forge-ediff-review-test--available)
+  (my-forge-ediff-review-test--with-conversation
+      (my-forge-ediff-review-test--conversation-session
+       (list (list :author "alice" :body "Looks good.")))
+    (with-current-buffer (my-forge-ediff-review--render-conversation)
+      (goto-char (point-max))
+      (let ((before (point)))
+        (my-forge-ediff-review--render-conversation)
+        (should (= before (point)))))))
+
+(ert-deftest my-forge-ediff-review-conversation-stores-fetched-comments ()
+  "A response for the session's own PR replaces the seed and keeps the id."
+  (skip-unless my-forge-ediff-review-test--available)
+  (my-forge-ediff-review-test--with-conversation
+      (my-forge-ediff-review-test--conversation-session
+       (list (list :author "seed" :body "from forge")))
+    (my-forge-ediff-review--on-conversation-fetched
+     '((data (repository
+              (pullRequest
+               (id . "PR_kwABC")
+               (comments (nodes . (((body . "from api")
+                                    (author (login . "bob"))))))))))
+     42)
+    (let ((posts (plist-get my-forge-ediff-review--session :conversation)))
+      (should (= 1 (length posts)))
+      (should (equal "from api" (plist-get (car posts) :body))))
+    (should (equal "PR_kwABC"
+                   (plist-get my-forge-ediff-review--session :pr-node-id)))))
+
+(ert-deftest my-forge-ediff-review-conversation-ignores-other-pr-response ()
+  "A reply that outlives its session must not land under another PR."
+  (skip-unless my-forge-ediff-review-test--available)
+  (my-forge-ediff-review-test--with-conversation
+      (my-forge-ediff-review-test--conversation-session
+       (list (list :author "seed" :body "from forge")))
+    (my-forge-ediff-review--on-conversation-fetched
+     '((data (repository
+              (pullRequest
+               (id . "PR_other")
+               (comments (nodes . (((body . "wrong PR")
+                                    (author (login . "eve"))))))))))
+     99)
+    (should (equal "from forge"
+                   (plist-get
+                    (car (plist-get my-forge-ediff-review--session
+                                    :conversation))
+                    :body)))
+    (should-not (plist-get my-forge-ediff-review--session :pr-node-id))))
+
 (provide 'my-forge-ediff-review-test)
 ;;; my-forge-ediff-review-test.el ends here


### PR DESCRIPTION
Base of the P0 stack for #325. Everything else in the tier branches off this one.

## What this does

The ediff review could show a PR's title and description but none of the discussion around it, so GitHub's whole Conversation tab was invisible without leaving Emacs. This grows the description buffer into that tab: the PR body is still first, and the PR-level comments now follow it in order.

Comments come from two places. Forge already caches them as `forge-pullreq-post` objects, so the session seeds `:conversation` from its database at start and the buffer has content the instant it opens — and stays readable with no network at all. Opening it also fires a GraphQL fetch that replaces the seed, so what you read is current when you are online. That fetch records the PR's node id too, which the GraphQL mutations for merging and draft state will need later.

`D` still opens the buffer; `g` refetches and `q` buries it. The command is renamed to reflect what it now shows, with an obsolete alias for the old name.

## Deviation from the roadmap

#325 says to reuse `format-card` for the comments. This renders them as plain markdown sections instead. A box has to re-wrap text to a fixed width, which breaks the code blocks, lists and quotes people actually write in PR discussions; a dedicated buffer has no code beside it to separate the annotation from, so the box earns nothing here. `format-time` is reused as planned.

## Details worth a second look

- The async callback checks the PR number it was issued for. A reply can outlive its session — quit, start reviewing a different PR — and would otherwise show one PR's discussion under another's title. The existing `reviewThreads` path has the same gap; it is fixed in the P0.4 PR rather than here.
- Redrawing preserves point, so a refresh landing mid-read does not pull you back to the top, and it never displays the buffer, so a fetch cannot steal a window during review.
- The buffer composes its keymap over the major mode instead of calling `local-set-key`, which would bind `g` in every markdown buffer by mutating the keymap they all share.
- `format-time` no longer signals on an unparsable timestamp. A date is decoration, and one odd value out of forge's database should not abort the render of a whole buffer of comments.

Only the first 100 comments are fetched — following the cursor past that is P0.4.

## The two supporting commits

**Run CI on every pull request.** The workflow only fired for PRs whose base was main, so every stacked PR in this tier would have run no tests at all. The `push` trigger stays scoped to main, so this adds runs for review, not for every push to every branch.

**Define the customize group.** Five defcustoms and deffaces carried `:group 'my-forge-ediff-review` but no such group was ever defined, so they attached to a symbol customize does not know. All five now resolve into a real group, which also gives the faces added by later features somewhere to live.

## Verification

- 83 ERT tests pass — 70 model, 13 editor/buffer — covering the parser, the layout, point preservation, the read-only keymap and the stale-response guard.
- Ran locally on Emacs 29.3 (CI uses 30.1). MELPA is blocked in my environment, so magit/ghub could not be installed for real; the integration tests were exercised against a stub so they ran rather than skipped. CI installs the real packages.
- The full suite has one unrelated pre-existing failure, `my-vterm-toggle-...-ignore-non-vterm-windows`, which fails on its own with none of these files loaded.
- No live API call was made from this environment; the GraphQL parsing is covered by response-shaped fixtures.

Manual check: open a forge PR, `C-c M e`, then `D` — the discussion appears under the description, and `g` refetches it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM8NbTysANnGuJdbotTujs)_